### PR TITLE
Adding Sync feature for registry

### DIFF
--- a/feathr_project/feathr/_feature_registry.py
+++ b/feathr_project/feathr/_feature_registry.py
@@ -581,3 +581,32 @@ class _FeatureRegistry():
                 feature_list.append(entity["name"])
 
         return feature_list
+
+    def sync_features_from_registry(self, project_name: str, workspace_path: str):
+        """[Sync Features from registry to local workspace, given a project_name, will write project's features from registry to to user's local workspace]
+
+        Args:
+            project_name (str): project name.
+            workspace_path (str): path to a workspace.
+
+        """
+
+        entities = self.purview_client.get_entity(qualifiedName=project_name,
+                                                    typeName="feathr_workspace")
+        # TODO - Change implementation to support traversing the workspace and construct the file, item by item 
+        # We don't support modifying features outside of registring this should be fine.
+        file_content = entities["entities"][0]["attributes"]["raw_hocon_feature_definition_config"]
+
+        feature_conf_dir = os.path.join(workspace_path,"feature_conf")
+        feature_conf_path = ""
+        if os.path.exists(feature_conf_dir):
+            feature_conf_path = os.path.join(workspace_path,"feature_conf", 'feature.conf')
+        else:
+            os.makedirs(feature_conf_dir)
+            feature_conf_path = os.path.join(workspace_path,"feature_conf", 'feature.conf')
+
+        logger.info("Writing feature configuration from feathr registry to {}",
+                    feature_conf_path)
+        f = open(feature_conf_path, "w")
+        f.write(file_content)
+        f.close()

--- a/feathr_project/feathr/client.py
+++ b/feathr_project/feathr/client.py
@@ -114,6 +114,12 @@ class FeathrClient(object):
         """
         return self.registry.list_registered_features(project_name)
 
+    def sync_features(self, project_name):
+        '''
+        Sync features from the registry given a project name
+        '''
+        self.registry.sync_features_from_registry(project_name, os.path.abspath("./"))
+    
     def get_registry_client(self):
         """
         Returns registry client in case users want to perform more advanced operations


### PR DESCRIPTION
Open questions
1. Should we support sync this way or traverse through entities (workspace--> anchors, derivations, sources). Since we don't support modifying features in CLI, It will yield same result. But someone might update features in Purview and this won't capture that. Open to suggestions here.
2. Currently this only works for feature.conf file and only creates a new file. Should we support appending if the file already exists? And should we do the same thing for other conf files too ( join and generation)
