### PR TITLE
Added typecheck for the registry tags

### DIFF
--- a/feathr_project/feathr/anchor.py
+++ b/feathr_project/feathr/anchor.py
@@ -30,7 +30,8 @@ class FeatureAnchor(HoconConvertible):
         self.name = name
         self.features = features
         self.source = source
-        self.registry_tags=registry_tags
+        # adding typecheck for registry tags incase user could also do like this {"description", "this is a test feature"} as well as like this dictionary format {"description":"this is a test feature"}
+        self.registry_tags=registry_tags if isinstance(registry_tags,Dict) else dict([registry_tags])
         self.validate_features()
 
     def validate_features(self):

--- a/feathr_project/feathr/feature.py
+++ b/feathr_project/feathr/feature.py
@@ -33,7 +33,8 @@ class FeatureBase(HoconConvertible):
         FeatureBase.validate_feature_name(name)
         self.name = name
         self.feature_type = feature_type
-        self.registry_tags=registry_tags
+        # adding typecheck for registry tags incase user could also do like this {"description", "this is a test feature"} as well as like this dictionary format {"description":"this is a test feature"}
+        self.registry_tags=registry_tags if isinstance(registry_tags,Dict) else dict([registry_tags])
         self.key = key if isinstance(key, List) else [key]
         # feature_alias: Rename the derived feature to `feature_alias`. Default to feature name.
         self.feature_alias = name

--- a/feathr_project/feathr/source.py
+++ b/feathr_project/feathr/source.py
@@ -48,7 +48,8 @@ class Source(HoconConvertible):
         self.name = name
         self.event_timestamp_column = event_timestamp_column
         self.timestamp_format = timestamp_format
-        self.registry_tags = registry_tags
+        # adding typecheck for registry tags incase user could also do like this {"description", "this is a test feature"} as well as like this dictionary format {"description":"this is a test feature"}
+        self.registry_tags=registry_tags if isinstance(registry_tags,Dict) else dict([registry_tags])
 
     def __eq__(self, other):
         """A source is equal to another if name is equal."""


### PR DESCRIPTION
Small changes to add type check for registry tags to check if registry_tags is a valid Dict[str, str] parameter.
the registry tags are in a dictionary format like this:

{"description":"this is a test feature"},so valid dictionary parameter.
and if the user does something like this

{"description", "this is a test feature"}, it'll also validate it.