### PR TITLE
Added _scproxy necessary for MacOS

### DIFF
--- a/registry/sql-registry/registry/database.py
+++ b/registry/sql-registry/registry/database.py
@@ -3,9 +3,13 @@ from contextlib import contextmanager
 import logging
 import threading
 import os
+
+# Checks if the platform is Max (Darwin).
+# If so, imports _scproxy that is necessary for pymssql to work on MacOS
 import platform
 if platform.system().lower().startswith('dar'):
     import _scproxy
+
 import pymssql
 
 

--- a/registry/sql-registry/registry/database.py
+++ b/registry/sql-registry/registry/database.py
@@ -3,7 +3,9 @@ from contextlib import contextmanager
 import logging
 import threading
 import os
-import _scproxy
+import platform
+if platform.system().lower().startswith('dar'):
+    import _scproxy
 import pymssql
 
 

--- a/registry/sql-registry/registry/database.py
+++ b/registry/sql-registry/registry/database.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 import logging
 import threading
 import os
+import _scproxy
 import pymssql
 
 
@@ -53,7 +54,7 @@ class MssqlConnection(DbConnection):
         self.params = params
         self.make_connection()
         self.mutex = threading.Lock()
-        
+
     def make_connection(self):
         self.conn = pymssql.connect(**self.params)
 
@@ -85,10 +86,10 @@ class MssqlConnection(DbConnection):
         """
         Start a transaction so we can run multiple SQL in one batch.
         User should use `with` with the returned value, look into db_registry.py for more real usage.
-        
+
         NOTE: `self.query` and `self.execute` will use a different MSSQL connection so any change made
         in this transaction will *not* be visible in these calls.
-        
+
         The minimal implementation could look like this if the underlying engine doesn't support transaction.
         ```
         @contextmanager


### PR DESCRIPTION
Signed-off-by: changyonglik <theeahlag@gmail.com>

## Description
<!--
Hey! Thank you for the contribution! Please go through https://github.com/linkedin/feathr/blob/main/docs/dev_guide/pull_request_guideline.md for more information.

Describe what changes to make and why you are making these changes.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Resolves #630 

## How was this PR tested?
<!--
Describe what testings you have done. If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Tested running sql-registry on MacOS
- [x] Mac0S (_scproxy is installed in MacOS by default)
- [x] Linux (Amazon Linux EC2. _scproxy is not installed in MacOS by default. So, conditional import is required for MacOS)
- [x] Windows (Amazon Windows EC2. _scproxy is not installed in Windows by default. So, conditional import is required for Windows)

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide UI screenshot, the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to clarify your proposed changes.
Added the following snippets to fix pymssql's MacOS Symbol not found on Mac
```python
# Checks if the platform is Max (Darwin).
# If so, imports _scproxy that is necessary for pymssql to work on MacOS
import platform
if platform.system().lower().startswith('dar'):
    import _scproxy

import pymssql
```