### PR TITLE
Adding DevSkim linter to Github actions

### DIFF
--- a/.github/workflows/devskim-security-linter.yml
+++ b/.github/workflows/devskim-security-linter.yml
@@ -1,0 +1,35 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party (Microsoft) and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# For more details about Devskim, visit https://github.com/marketplace/actions/devskim 
+
+name: DevSkim
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '25 4 * * 2'
+
+jobs:
+  lint:
+    name: DevSkim
+    runs-on: ubuntu-20.04
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run DevSkim scanner
+        uses: microsoft/DevSkim-Action@v1
+        
+      - name: Upload DevSkim scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: devskim-results.sarif

--- a/.github/workflows/devskim-security-linter.yml
+++ b/.github/workflows/devskim-security-linter.yml
@@ -12,7 +12,7 @@ on:
   pull_request:
     branches: [ "main" ]
   schedule:
-    - cron: '25 4 * * 2'
+    - cron: '00 4 * * *'
 
 jobs:
   lint:
@@ -28,6 +28,8 @@ jobs:
 
       - name: Run DevSkim scanner
         uses: microsoft/DevSkim-Action@v1
+        with:
+          ignore-globs: "**/.git/**,**/test/**"
         
       - name: Upload DevSkim scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2


### PR DESCRIPTION
## Description
Adding DevSkim Plugin to Github Action

DevSkim is security linter that highlights common security issues in source code.

The DevSkim GitHub Action outputs a sarif file compatible with GitHub's Security Issues view.

It is strongly suggested to be run for OSS projects.

## How was this PR tested?
Tested in my fork, here is a successful run.

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.