### PR TITLE
Enhance SQL Registry Error Messages

### DIFF
--- a/registry/sql-registry/main.py
+++ b/registry/sql-registry/main.py
@@ -37,7 +37,7 @@ def exc_to_content(e: Exception) -> dict:
     return content
 
 @app.exception_handler(ConflictError)
-async def http_exception_handler(_, exc: ConflictError):
+async def conflict_error_handler(_, exc: ConflictError):
     return JSONResponse(
         status_code=409,
         content=exc_to_content(exc),
@@ -45,7 +45,7 @@ async def http_exception_handler(_, exc: ConflictError):
 
 
 @app.exception_handler(ValueError)
-async def http_exception_handler(_, exc: ValueError):
+async def value_error_handler(_, exc: ValueError):
     return JSONResponse(
         status_code=400,
         content=exc_to_content(exc),
@@ -53,14 +53,14 @@ async def http_exception_handler(_, exc: ValueError):
 
 
 @app.exception_handler(KeyError)
-async def http_exception_handler(_, exc: KeyError):
+async def key_error_handler(_, exc: KeyError):
     return JSONResponse(
         status_code=404,
         content=exc_to_content(exc),
     )
 
 @app.exception_handler(IndexError)
-async def http_exception_handler(_, exc: IndexError):
+async def index_error_handler(_, exc: IndexError):
     return JSONResponse(
         status_code=404,
         content=exc_to_content(exc),

--- a/registry/sql-registry/main.py
+++ b/registry/sql-registry/main.py
@@ -51,6 +51,13 @@ async def value_error_handler(_, exc: ValueError):
         content=exc_to_content(exc),
     )
 
+@app.exception_handler(TypeError)
+async def type_error_handler(_, exc: ValueError):
+    return JSONResponse(
+        status_code=400,
+        content=exc_to_content(exc),
+    )
+
 
 @app.exception_handler(KeyError)
 async def key_error_handler(_, exc: KeyError):

--- a/registry/sql-registry/main.py
+++ b/registry/sql-registry/main.py
@@ -1,10 +1,12 @@
 import os
+import traceback
 from typing import Optional
 from uuid import UUID
 from fastapi import APIRouter, FastAPI, HTTPException
+from fastapi.responses import JSONResponse
 from starlette.middleware.cors import CORSMiddleware
 from registry import *
-from registry.db_registry import DbRegistry
+from registry.db_registry import DbRegistry, ConflictError
 from registry.models import AnchorDef, AnchorFeatureDef, DerivedFeatureDef, EntityType, ProjectDef, SourceDef, to_snake
 
 rp = "/"
@@ -27,6 +29,42 @@ app.add_middleware(CORSMiddleware,
                    allow_methods=["*"],
                    allow_headers=["*"],
                    )
+
+def exc_to_content(e: Exception) -> dict:
+    content={"message": str(e)}
+    if os.environ.get("REGISTRY_DEBUGGING"):
+        content["traceback"] = "".join(traceback.TracebackException.from_exception(e).format())
+    return content
+
+@app.exception_handler(ConflictError)
+async def http_exception_handler(request, exc: ValueError):
+    return JSONResponse(
+        status_code=409,
+        content=exc_to_content(exc),
+    )
+
+
+@app.exception_handler(ValueError)
+async def http_exception_handler(request, exc: ValueError):
+    return JSONResponse(
+        status_code=400,
+        content=exc_to_content(exc),
+    )
+
+
+@app.exception_handler(KeyError)
+async def validation_exception_handler(request, exc):
+    return JSONResponse(
+        status_code=404,
+        content=exc_to_content(exc),
+    )
+
+@app.exception_handler(IndexError)
+async def validation_exception_handler(request, exc):
+    return JSONResponse(
+        status_code=404,
+        content=exc_to_content(exc),
+    )
 
 
 @router.get("/projects")

--- a/registry/sql-registry/main.py
+++ b/registry/sql-registry/main.py
@@ -37,7 +37,7 @@ def exc_to_content(e: Exception) -> dict:
     return content
 
 @app.exception_handler(ConflictError)
-async def http_exception_handler(request, exc: ValueError):
+async def http_exception_handler(_, exc: ConflictError):
     return JSONResponse(
         status_code=409,
         content=exc_to_content(exc),
@@ -45,7 +45,7 @@ async def http_exception_handler(request, exc: ValueError):
 
 
 @app.exception_handler(ValueError)
-async def http_exception_handler(request, exc: ValueError):
+async def http_exception_handler(_, exc: ValueError):
     return JSONResponse(
         status_code=400,
         content=exc_to_content(exc),
@@ -53,14 +53,14 @@ async def http_exception_handler(request, exc: ValueError):
 
 
 @app.exception_handler(KeyError)
-async def validation_exception_handler(request, exc):
+async def http_exception_handler(_, exc: KeyError):
     return JSONResponse(
         status_code=404,
         content=exc_to_content(exc),
     )
 
 @app.exception_handler(IndexError)
-async def validation_exception_handler(request, exc):
+async def http_exception_handler(_, exc: IndexError):
     return JSONResponse(
         status_code=404,
         content=exc_to_content(exc),

--- a/registry/sql-registry/registry/__init__.py
+++ b/registry/sql-registry/registry/__init__.py
@@ -3,4 +3,4 @@ __all__ = ["interface", "models", "database", "db_registry"]
 from registry.models import *
 from registry.interface import Registry
 from registry.database import DbConnection, connect
-from registry.db_registry import DbRegistry
+from registry.db_registry import DbRegistry, ConflictError


### PR DESCRIPTION
## Description
<!--
Hey! Thank you for the contribution! Please go through https://github.com/feathr-ai/feathr/blob/main/docs/dev_guide/pull_request_guideline.md for more information.

Describe what changes to make and why you are making these changes.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Right now the SQL registry returns all errors as `500 Internal Error`, this PR improves the error handling and returns 400/404/409 on corresponding criteria.

Also it introduces an environment variable `REGISTRY_DEBUGGING`, the returned HTTP error will include the detailed track back info when it's set to non-empty string. This variable should only be used for debugging purposes.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide UI screenshot, the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
