### PR TITLE
Remove reference to aerospike JAR in sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,8 +47,7 @@ val localAndCloudCommonDependencies = Seq(
     "com.github.changvvb" %% "jackson-module-caseclass" % "1.1.1",
     "com.azure.cosmos.spark" % "azure-cosmos-spark_3-1_2-12" % "4.11.1",
     "org.elasticsearch" % "elasticsearch-spark-30_2.12" % "7.15.2",
-    "org.eclipse.jetty" % "jetty-util" % "9.3.24.v20180605",
-    "com.aerospike" % "aerospike-spark_2.12" % "3.3.0_spark3.1-allshaded"
+    "org.eclipse.jetty" % "jetty-util" % "9.3.24.v20180605"
 ) // Common deps
 
 val jdbcDrivers = Seq(


### PR DESCRIPTION
Aerospike JAR has downstream dependency conflict with existing runtime in feathr core, 
This runtime error was not triggered during testing aerospike sink, but was identified in sbt test. 

Revert this change for now, next step to do with aerospike TBD.

Resolves issue https://github.com/feathr-ai/feathr/issues/678