### PR TITLE
Enhance purview registry error messages

### DIFF
--- a/docs/dev_guide/build-and-push-feathr-registry-docker-image.md
+++ b/docs/dev_guide/build-and-push-feathr-registry-docker-image.md
@@ -77,3 +77,7 @@ docker push feathrfeaturestore/feathr-registry
 ## Published Feathr Registry Image
 
 The published feathr feature registry is located in [DockerHub here](https://hub.docker.com/r/feathrfeaturestore/feathr-registry).
+
+## Include the detailed track back info in registry api HTTP error response
+
+Set environment REGISTRY_DEBUGGING to any non empty string will enable the detailed track back info in registry api http response. This variable is helpful for python client debugging and should only be used for debugging purposes.

--- a/registry/purview-registry/main.py
+++ b/registry/purview-registry/main.py
@@ -1,11 +1,12 @@
 import os
+import traceback
 from re import sub
 from typing import Optional
 from uuid import UUID
 from fastapi import APIRouter, FastAPI, HTTPException
+from fastapi.responses import JSONResponse
 from starlette.middleware.cors import CORSMiddleware
-from registry import *
-from registry.purview_registry import PurviewRegistry
+from registry.purview_registry import PurviewRegistry, ConflictError
 from registry.models import AnchorDef, AnchorFeatureDef, DerivedFeatureDef, EntityType, ProjectDef, SourceDef, to_snake
 
 rp = "/v1"
@@ -43,6 +44,48 @@ app.add_middleware(CORSMiddleware,
                    allow_headers=["*"],
                    )
 
+def exc_to_content(e: Exception) -> dict:
+    content={"message": str(e)}
+    if os.environ.get("REGISTRY_DEBUGGING"):
+        content["traceback"] = "".join(traceback.TracebackException.from_exception(e).format())
+    return content
+
+@app.exception_handler(ConflictError)
+async def conflict_error_handler(_, exc: ConflictError):
+    return JSONResponse(
+        status_code=409,
+        content=exc_to_content(exc),
+    )
+
+
+@app.exception_handler(ValueError)
+async def value_error_handler(_, exc: ValueError):
+    return JSONResponse(
+        status_code=400,
+        content=exc_to_content(exc),
+    )
+
+@app.exception_handler(TypeError)
+async def type_error_handler(_, exc: ValueError):
+    return JSONResponse(
+        status_code=400,
+        content=exc_to_content(exc),
+    )
+
+
+@app.exception_handler(KeyError)
+async def key_error_handler(_, exc: KeyError):
+    return JSONResponse(
+        status_code=404,
+        content=exc_to_content(exc),
+    )
+
+@app.exception_handler(IndexError)
+async def index_error_handler(_, exc: IndexError):
+    return JSONResponse(
+        status_code=404,
+        content=exc_to_content(exc),
+    )
 
 @router.get("/projects",tags=["Project"])
 def get_projects() -> list[str]:


### PR DESCRIPTION
## Description
<!--
Hey! Thank you for the contribution! Please go through https://github.com/feathr-ai/feathr/blob/main/docs/dev_guide/pull_request_guideline.md for more information.

Describe what changes to make and why you are making these changes.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR is to follow up on PR #674 to port the fix to purview registry.

## How was this PR tested?
<!--
Describe what testings you have done. If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

Test register same project twice with python client to purview registry, the 2nd registration now fails with 409 conflict error code: 
```
RuntimeError: Failed to call registry API, status is 409, error is {"message":"Entity -1001, feathr_workspace_v1 -- blair_0927.1 already exists in Purview. Please use a new name."}
```

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide UI screenshot, the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.