### PR TITLE
Fix lookup feature missing issue when converting feature definition to HOCON files

### DIFF
--- a/feathr_project/feathr/definition/lookup_feature.py
+++ b/feathr_project/feathr/definition/lookup_feature.py
@@ -4,12 +4,13 @@ from typing import List, Optional, Union, Dict
 from jinja2 import Template
 
 from feathr.definition.dtype import FeatureType
+from feathr.definition.feature_derivations import DerivedFeature
 from feathr.definition.feature import FeatureBase
 from feathr.definition.transformation import RowTransformation
 from feathr.definition.typed_key import DUMMY_KEY, TypedKey
 from feathr.definition.aggregation import Aggregation
 
-class LookupFeature(FeatureBase):
+class LookupFeature(DerivedFeature):
     """A lookup feature is a feature defined on top of two other features, i.e. using the feature value of the base feature as key, to lookup the feature value from the expansion feature.
     e.g. a lookup feature user_purchased_item_avg_price could be key-ed by user_id, and computed by:
     base feature is user_purchased_item_ids. For a given user_id, it returns the item ids purchased by the user.
@@ -36,7 +37,8 @@ class LookupFeature(FeatureBase):
                 key: Optional[Union[TypedKey, List[TypedKey]]] = [DUMMY_KEY],
                 registry_tags: Optional[Dict[str, str]] = None,
                 ):
-        super(LookupFeature, self).__init__(name, feature_type, key=key, registry_tags=registry_tags)
+        super(LookupFeature, self).__init__(name, feature_type, input_features=[base_feature, expansion_feature],
+                                            transform="", key=key, registry_tags=registry_tags)
         self.base_feature = base_feature
         self.expansion_feature = expansion_feature
         self.aggregation = aggregation

--- a/feathr_project/test/test_lookup_feature.py
+++ b/feathr_project/test/test_lookup_feature.py
@@ -1,6 +1,7 @@
 from feathr import Aggregation
 from feathr import Feature
 from feathr import LookupFeature
+from feathr import DerivedFeature
 from feathr import FLOAT, FLOAT_VECTOR, ValueType, INT32_VECTOR
 from feathr import TypedKey
 
@@ -39,4 +40,5 @@ def test_single_key_lookup_feature_to_config():
         }
     }"""
     assert_config_equals(lookup_feature.to_feature_config(), lookup_feature_config)
+    assert(isinstance(lookup_feature, DerivedFeature))
  


### PR DESCRIPTION
Have LookupFeature inherit from DerivedFeature so that feature registry can handle it as a normal derived feature.
 
This resolves the issue where Lookup feature is skipped when `feathr hocon` converts feature definition to HOCON config, as it only handles anchor features, derived features and passthrough features.