### PR TITLE
Fix synapse errors not print out issue

### DIFF
--- a/feathr_project/feathr/spark_provider/_synapse_submission.py
+++ b/feathr_project/feathr/spark_provider/_synapse_submission.py
@@ -325,7 +325,7 @@ class _SynapseJobRunner(object):
     def get_driver_log(self, job_id) -> str:
         # @see: https://docs.microsoft.com/en-us/azure/synapse-analytics/spark/connect-monitor-azure-synapse-spark-application-level-metrics
         app_id = self.get_spark_batch_job(job_id).app_id
-        url = "%s/sparkhistory/api/v1/sparkpools/%s/livyid/%s/applications/%s/driverlog/stdout/?isDownload=true" % (self._synapse_dev_url, self._spark_pool_name, job_id, app_id)
+        url = "%s/sparkhistory/api/v1/sparkpools/%s/livyid/%s/applications/%s/driverlog/stderr/?isDownload=true" % (self._synapse_dev_url, self._spark_pool_name, job_id, app_id)
         token = self._credential.get_token("https://dev.azuresynapse.net/.default").token
         req = urllib.request.Request(url=url, headers={"authorization": "Bearer %s" % token})
         resp = urllib.request.urlopen(req)


### PR DESCRIPTION
## Description
<!--
Hey! Thank you for the contribution! Please go through https://github.com/feathr-ai/feathr/blob/main/docs/dev_guide/pull_request_guideline.md for more information.

Describe what changes to make and why you are making these changes.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
- Currently we get logs from spark pool by requesting 'stdout' folder. It can only get logs when we have 'feathr_pyspark_driver.py' submitted (when applying 'preprocessing'). All error logs should be under 'stderr' folder. So changed the url to get error logs.

## How was this PR tested?
<!--
Describe what testings you have done. If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- Tested locally by creating error cases. Got logs like below:

<img width="885" alt="Screen Shot 2022-10-11 at 17 27 14" src="https://user-images.githubusercontent.com/108409954/195052874-9642ae92-e766-4994-a207-cf359b76f84f.png">



## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide UI screenshot, the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.