### PR TITLE
Fix direct purview client missing transformation

### DIFF
--- a/feathr_project/feathr/registry/_feature_registry_purview.py
+++ b/feathr_project/feathr/registry/_feature_registry_purview.py
@@ -1368,11 +1368,11 @@ derivations: {
         if 'transformExpr' in input:
             # it's ExpressionTransformation
             return ExpressionTransformation(input['transformExpr'])
-        elif 'def_expr' in input:
-            agg_expr=input['def_expr'] if 'def_expr' in input else None
-            agg_func=input['agg_func']if 'agg_func' in input else None
+        elif 'def_expr' in input or 'defExpr' in input: 
+            agg_expr=input['def_expr'] if 'def_expr' in input else (input['defExpr'] if 'defExpr' in input else None)
+            agg_func=input['agg_func']if 'agg_func' in input else (input['aggFunc'] if 'aggFunc' in input else None)
             window=input['window']if 'window' in input else None
-            group_by=input['group_by']if 'group_by' in input else None
+            group_by=input['group_by']if 'group_by' in input else (input['groupBy'] if 'groupBy' in input else None)
             filter=input['filter']if 'filter' in input else None
             limit=input['limit']if 'limit' in input else None
             return WindowAggTransformation(agg_expr, agg_func, window, group_by, filter, limit)


### PR DESCRIPTION
## Description
This PR fixes the bug , where using direct purview connection, uploading a feature with transformation, after the creation, call "get feature from registry", the returned feature does not contain transfomration info.

Resolves #XXX

## How was this PR tested?
<!--
Describe what testings you have done. If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide UI screenshot, the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
