### PR TITLE
remove unnecessary spark job from registry test

### DIFF
--- a/feathr_project/test/test_feature_registry.py
+++ b/feathr_project/test/test_feature_registry.py
@@ -59,18 +59,6 @@ class FeatureRegistryTests(unittest.TestCase):
                 # Sync workspace from registry, will get all conf files back
                 client.get_features_from_registry(client.project_name)
 
-                feature_query = FeatureQuery(
-                    feature_list=["f_location_avg_fare", "f_trip_time_rounded", "f_is_long_trip_distance"],
-                    key=TypedKey(key_column="DOLocationID",key_column_type=ValueType.INT32))
-                settings = ObservationSettings(
-                    observation_path="wasbs://public@azurefeathrstorage.blob.core.windows.net/sample_data/green_tripdata_2020-04_with_index.csv",
-                    event_timestamp_column="lpep_dropoff_datetime",
-                    timestamp_format="yyyy-MM-dd HH:mm:ss")
-                client.get_offline_features(observation_settings=settings,
-                                            feature_query=feature_query,
-                                            output_path=output_path)
-                client.wait_job_to_finish(timeout_sec=Constants.SPARK_JOB_TIMEOUT_SECONDS)
-
     def test_feathr_register_features_partially(self):
         """
         This test will register full set of features into one project, then register another project in two partial registrations.


### PR DESCRIPTION
Signed-off-by: Yuqing Wei <weiyuqing021@outlook.com>

## Description
<!--
Hey! Thank you for the contribution! Please go through https://github.com/feathr-ai/feathr/blob/main/docs/dev_guide/pull_request_guideline.md for more information.

Describe what changes to make and why you are making these changes.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Based on CI failure here: https://github.com/feathr-ai/feathr/actions/runs/3279090567/jobs/5398225684#step:8:510

`feathr_project/test/test_feature_registry.py` is marked as F but the RuntimeError: Spark job failed. has nothing todo with registry itself.

By removing the unnecessary spark job, test cost will be saved and only feature register use case will be tested. 

## How was this PR tested?
<!--
Describe what testings you have done. If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide UI screenshot, the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.