### PR TITLE
Revert pytest-xdist

### DIFF
--- a/.github/workflows/pull_request_push_test.yml
+++ b/.github/workflows/pull_request_push_test.yml
@@ -128,7 +128,7 @@ jobs:
           SQL1_PASSWORD: ${{secrets.SQL1_PASSWORD}}
         run: |
           # run only test with databricks. run in 4 parallel jobs
-          pytest -n 6 feathr_project/test/
+          pytest feathr_project/test/
 
   azure_synapse_test:
     # might be a bit duplication to setup both the azure_synapse test and databricks test, but for now we will keep those to accelerate the test speed
@@ -197,7 +197,7 @@ jobs:
         run: |
           # skip databricks related test as we just ran the test; also seperate databricks and synapse test to make sure there's no write conflict
           # run in 4 parallel jobs to make the time shorter
-          pytest -n 6 feathr_project/test/
+          pytest feathr_project/test/
 
   local_spark_test:
     runs-on: ubuntu-latest

--- a/feathr_project/setup.py
+++ b/feathr_project/setup.py
@@ -23,7 +23,6 @@ extras_require=dict(
         "black>=22.1.0",    # formatter
         "isort",            # sort import statements
         "pytest>=7",
-        "pytest-xdist",
         "pytest-mock>=3.8.1",
     ],
     notebook=[


### PR DESCRIPTION
## Description
<!--
Hey! Thank you for the contribution! Please go through https://github.com/feathr-ai/feathr/blob/main/docs/dev_guide/pull_request_guideline.md for more information.

Describe what changes to make and why you are making these changes.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR reverts pytest-xdist added by PR #773, with pytest-xdist, now ci tests fail with `Different tests were collected between gw4 and gw5.`

For more details please read: https://github.com/pytest-dev/pytest-xdist/issues/432

After discussing with @loomlike , the root cause is in following code, NamedTemporaryFile().name confuses xdist. He will submit a right fix to mitigate this issue. 
```python
@pytest.mark.parametrize(
    "output_filepath", [None, NamedTemporaryFile().name],
)
def test__generate_config
```

## How was this PR tested?
<!--
Describe what testings you have done. If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide UI screenshot, the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.