### PR TITLE
Fix test_azure_spark_maven_e2e ci test error

### DIFF
--- a/feathr_project/test/test_azure_kafka_e2e.py
+++ b/feathr_project/test/test_azure_kafka_e2e.py
@@ -19,5 +19,5 @@ def test_feathr_kafa_streaming_features():
                                    sinks=[redisSink],
                                    feature_names=['f_modified_streaming_count']
                                    )
-    client.materialize_features(settings)
+    client.materialize_features(settings, allow_materialize_non_agg_feature=True)
     client.wait_job_to_finish(timeout_sec=Constants.SPARK_JOB_TIMEOUT_SECONDS)

--- a/feathr_project/test/test_azure_spark_maven_e2e.py
+++ b/feathr_project/test/test_azure_spark_maven_e2e.py
@@ -45,7 +45,7 @@ def test_feathr_online_store_agg_features():
     if client.spark_runtime == 'databricks':
         output_path = ''.join(['dbfs:/feathrazure_cijob','_', str(now.minute), '_', str(now.second), ".avro"])
     else:
-        output_path = ''.join(['abfss://xchfeathrtest4fs@xchfeathrtest4sto.dfs.core.windows.net/demo_data/output','_', str(now.minute), '_', str(now.second), ".avro"])
+        output_path = ''.join(['abfss://feathrazuretest3fs@xchfeathrtest4sto.dfs.core.windows.net/demo_data/output','_', str(now.minute), '_', str(now.second), ".avro"])
 
 
     client.get_offline_features(observation_settings=settings,

--- a/feathr_project/test/test_azure_spark_maven_e2e.py
+++ b/feathr_project/test/test_azure_spark_maven_e2e.py
@@ -45,7 +45,7 @@ def test_feathr_online_store_agg_features():
     if client.spark_runtime == 'databricks':
         output_path = ''.join(['dbfs:/feathrazure_cijob','_', str(now.minute), '_', str(now.second), ".avro"])
     else:
-        output_path = ''.join(['abfss://feathrazuretest3fs@xchfeathrtest4sto.dfs.core.windows.net/demo_data/output','_', str(now.minute), '_', str(now.second), ".avro"])
+        output_path = ''.join(['abfss://feathrazuretest3fs@feathrazuretest3storage.dfs.core.windows.net/demo_data/output','_', str(now.minute), '_', str(now.second), ".avro"])
 
 
     client.get_offline_features(observation_settings=settings,


### PR DESCRIPTION
## Description
<!--
Hey! Thank you for the contribution! Please go through https://github.com/feathr-ai/feathr/blob/main/docs/dev_guide/pull_request_guideline.md for more information.

Describe what changes to make and why you are making these changes.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR fixes test_azure_spark_maven_e2e ci test error. Once this PR is in, it's expected all ci test can pass on main branch. The fix is to update test_azure_spark_maven_e2e use same output path as other test cases. 

## How was this PR tested?
<!--
Describe what testings you have done. If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide UI screenshot, the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
No