### PR TITLE
Fix bug in empty array dense tensor default value

### DIFF
--- a/src/main/scala/com/linkedin/feathr/offline/transformation/DefaultValueSubstituter.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/transformation/DefaultValueSubstituter.scala
@@ -112,7 +112,7 @@ private[offline] object DataFrameDefaultValueSubstituter extends DataFrameDefaul
         // For tensor default, since we don't have type, so we need to use expr to construct the default column
         val schema = field.dataType
         val tensorData = defaultFeatureValue.getAsTensorData
-        val ts = FeaturizedDatasetUtils.tensorToFDSDataFrameRow(tensorData)
+        val ts = FeaturizedDatasetUtils.tensorToFDSDataFrameRow(tensorData, Some(schema))
         val fdsTensorDefaultUDF = getFDSTensorDefaultUDF(schema, ts)
         ss.udf.register("tz_udf", fdsTensorDefaultUDF)
         expr(s"tz_udf($featureColumnName)")

--- a/src/test/scala/com/linkedin/feathr/offline/AnchoredFeaturesIntegTest.scala
+++ b/src/test/scala/com/linkedin/feathr/offline/AnchoredFeaturesIntegTest.scala
@@ -58,6 +58,16 @@ class AnchoredFeaturesIntegTest extends FeathrIntegTest {
       |       type: "DENSE_VECTOR"
       |       default: [7,8,9]
       |      }
+      |      ee2: {
+      |       def: "c"
+      |       type: {
+      |           type: TENSOR
+      |           tensorCategory: DENSE
+      |           dimensionType: [INT]
+      |           valType: FLOAT
+      |           }
+      |       default: []
+      |      }
       |      ff: {
       |       def: "c"
       |       default: [6,7]
@@ -155,7 +165,7 @@ class AnchoredFeaturesIntegTest extends FeathrIntegTest {
    */
   @Test
   def testSingleKeyJoinWithDifferentFeatureTypes(): Unit = {
-    val selectedColumns = Seq("x", "aa", "bb", "cc", "dd", "ee", "ff", "multiply_a_b", "categorical_b") // , "z")
+    val selectedColumns = Seq("x", "aa", "bb", "cc", "dd", "ee", "ee2", "ff", "multiply_a_b", "categorical_b") // , "z")
     val featureJoinConf =
       s"""
          |
@@ -186,6 +196,8 @@ class AnchoredFeaturesIntegTest extends FeathrIntegTest {
             null,
             // ee
             mutable.WrappedArray.make(Array(7.0f, 8.0f, 9.0f)),
+            // ee2
+            mutable.WrappedArray.empty,
             // ff
             mutable.WrappedArray.make(Array(6.0f, 7.0f)),
             // multiply_a_b
@@ -206,6 +218,8 @@ class AnchoredFeaturesIntegTest extends FeathrIntegTest {
             // dd
             mutable.WrappedArray.make(Array(1.0f, 2.0f, 3.0f)),
             // ee
+            mutable.WrappedArray.make(Array(1.0f, 2.0f, 3.0f)),
+            // ee2
             mutable.WrappedArray.make(Array(1.0f, 2.0f, 3.0f)),
             // ff
             mutable.WrappedArray.make(Array(1.0f, 2.0f, 3.0f)),
@@ -228,6 +242,8 @@ class AnchoredFeaturesIntegTest extends FeathrIntegTest {
             mutable.WrappedArray.make(Array(4.0f, 5.0f, 6.0f)),
             // ee
             mutable.WrappedArray.make(Array(4.0f, 5.0f, 6.0f)),
+            // ee2
+            mutable.WrappedArray.make(Array(4.0f, 5.0f, 6.0f)),
             // ff
             mutable.WrappedArray.make(Array(4.0f, 5.0f, 6.0f)),
             // multiply_a_b
@@ -246,6 +262,7 @@ class AnchoredFeaturesIntegTest extends FeathrIntegTest {
           StructField("cc", FloatType, true),
           StructField("dd", ArrayType(FloatType, true), true),
           StructField("ee", ArrayType(FloatType, false), true),
+          StructField("ee2", ArrayType(FloatType, false), true),
           StructField("ff", ArrayType(FloatType, false), true),
           StructField(
             "multiply_a_b",


### PR DESCRIPTION
## Description
Fix bug in empty default value array. Currently the return value of an empty dense tensor is a UniversalTensor and not a DenseTensor which breaks our default value code. To address this we can include the type information of the field when we try to do tensor conversion which allows the correct empty array to be created.

## How was this PR tested?
Added new test case in AnchoredFeaturesIntegTest and tested via following command
`sbt "testOnly *AnchoredFeaturesIntegTest" -java-home /Library/Java/JavaVirtualMachines/jdk1.8.0_282-msft.jdk/Contents/Home`

## Does this PR introduce any user-facing changes?
No