### PR TITLE
Replacing webapp-deploy action with workflow-webhook action.

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -54,25 +54,22 @@ jobs:
     steps:
       - name: Deploy to Feathr SQL Registry Azure Web App
         id: deploy-to-sql-webapp
-        uses: azure/webapps-deploy@v2
+        uses: distributhor/workflow-webhook
         with:
-          app-name: 'feathr-sql-registry'
-          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_FEATHR_SQL_REGISTRY }}
-          images: 'feathrfeaturestore/feathr-registry:nightly'
+          url: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_FEATHR_SQL_REGISTRY }}
+          json: '{}'
     
       - name: Deploy to Feathr Purview Registry Azure Web App
         id: deploy-to-purview-webapp
-        uses: azure/webapps-deploy@v2
+        uses: distributhor/workflow-webhook
         with:
-          app-name: 'feathr-purview-registry'
-          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_FEATHR_PURVIEW_REGISTRY }}
-          images: 'feathrfeaturestore/feathr-registry:nightly'
+          url: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_FEATHR_SQL_REGISTRY }}
+          json: '{}'
 
       - name: Deploy to Feathr RBAC Registry Azure Web App
         id: deploy-to-rbac-webapp
-        uses: azure/webapps-deploy@v2
+        uses: distributhor/workflow-webhook
         with:
-          app-name: 'feathr-rbac-registry'
-          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_FEATHR_RBAC_REGISTRY }}
-          images: 'feathrfeaturestore/feathr-registry:nightly'
+          url: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_FEATHR_SQL_REGISTRY }}
+          json: '{}'
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,24 +52,20 @@ jobs:
     
     
     steps:
-      - name: Deploy to Feathr SQL Registry Azure Web App
-        id: deploy-to-sql-webapp
-        uses: distributhor/workflow-webhook
-        with:
-          url: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_FEATHR_SQL_REGISTRY }}
-          json: '{}'
-    
       - name: Deploy to Feathr Purview Registry Azure Web App
         id: deploy-to-purview-webapp
-        uses: distributhor/workflow-webhook
-        with:
-          url: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_FEATHR_SQL_REGISTRY }}
-          json: '{}'
+        uses: distributhor/workflow-webhook@v3.0.1
+        env:
+          webhook_url: ${{ secrets.AZURE_WEBAPP_FEATHR_PURVIEW_REGISTRY_WEBHOOK }}
 
       - name: Deploy to Feathr RBAC Registry Azure Web App
         id: deploy-to-rbac-webapp
-        uses: distributhor/workflow-webhook
-        with:
-          url: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_FEATHR_SQL_REGISTRY }}
-          json: '{}'
-
+        uses: distributhor/workflow-webhook@v3.0.1
+        env:
+          webhook_url: ${{ secrets.AZURE_WEBAPP_FEATHR_RBAC_REGISTRY_WEBHOOK }}
+          
+      - name: Deploy to Feathr SQL Registry Azure Web App
+        id: deploy-to-sql-webapp
+        uses: distributhor/workflow-webhook@v3.0.1
+        env:
+          webhook_url: ${{ secrets.AZURE_WEBAPP_FEATHR_SQL_REGISTRY_WEBHOOK }}


### PR DESCRIPTION
## Description
Current webapp-deploy action is mainly used when users need to push code to the webapp, it should ideally work for containers as well where it can directly call the webhook URL via the publish profile but that does not seem to work.

Replacing it instead with a simpler third party webhook action which just calls the webhook URL for App Service and that triggers the pull of latest sha for image tag from dockerhub.

https://github.com/distributhor/workflow-webhook

Resolves  the issue we have with our internal demo environments not getting updated with nightly docker tags.

## How was this PR tested?
tested it in my fork 
https://github.com/jainr/feathr/actions/runs/3376143908

<img width="1167" alt="image" src="https://user-images.githubusercontent.com/8405222/199452816-0d7d0595-5870-4644-a5f4-588c13d3aa86.png">


## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.