### PR TITLE
Update registry nightly deploy CICD

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,7 +15,6 @@ on:
     branches:
       - 'releases/**'
 
-
 jobs:
   build_and_push_image_to_registry:
     name: Push Docker image to Docker Hub
@@ -45,27 +44,32 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-  # Deploy the docker container to the three test environments for feathr
+  # Trigger Azure Web App webhooks to pull the latest nightly image
   deploy:
     runs-on: ubuntu-latest
     needs: build_and_push_image_to_registry
-    
-    
+
     steps:
-      - name: Deploy to Feathr Purview Registry Azure Web App
+      - name: Deploy to Azure Web App feathr-registry-purview
         id: deploy-to-purview-webapp
         uses: distributhor/workflow-webhook@v3.0.1
         env:
-          webhook_url: ${{ secrets.AZURE_WEBAPP_FEATHR_PURVIEW_REGISTRY_WEBHOOK }}
+          webhook_url: ${{ secrets.AZURE_WEBAPP_FEATHR_REGISTRY_PURVIEW_WEBHOOK }}
 
-      - name: Deploy to Feathr RBAC Registry Azure Web App
+      - name: Deploy to Azure Web App feathr-registry-purview-rbac
         id: deploy-to-rbac-webapp
         uses: distributhor/workflow-webhook@v3.0.1
         env:
-          webhook_url: ${{ secrets.AZURE_WEBAPP_FEATHR_RBAC_REGISTRY_WEBHOOK }}
-          
-      - name: Deploy to Feathr SQL Registry Azure Web App
+          webhook_url: ${{ secrets.AZURE_WEBAPP_FEATHR_REGISTRY_PURVIEW_RBAC_WEBHOOK }}
+
+      - name: Deploy to Azure Web App feathr-registry-sql
         id: deploy-to-sql-webapp
         uses: distributhor/workflow-webhook@v3.0.1
         env:
-          webhook_url: ${{ secrets.AZURE_WEBAPP_FEATHR_SQL_REGISTRY_WEBHOOK }}
+          webhook_url: ${{ secrets.AZURE_WEBAPP_FEATHR_REGISTRY_SQL_WEBHOOK }}
+
+      - name: Deploy to Azure Web App feathr-registry-sql-rbac
+        id: deploy-to-sql-webapp
+        uses: distributhor/workflow-webhook@v3.0.1
+        env:
+          webhook_url: ${{ secrets.AZURE_WEBAPP_FEATHR_REGISTRY_SQL_RBAC_WEBHOOK }}


### PR DESCRIPTION
## Description
<!--
Hey! Thank you for the contribution! Please go through https://github.com/feathr-ai/feathr/blob/main/docs/dev_guide/pull_request_guideline.md for more information.

Describe what changes to make and why you are making these changes.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR updates registry nightly deployment CICD. This will make following 4 sites always run latest registry nightly build.

- https://feathr-registry-purview.azurewebsites.net
- https://feathr-registry-purview-rbac.azurewebsites.net
- https://feathr-registry-sql.azurewebsites.net
- https://feathr-registry-sql-rbac.azurewebsites.net

## How was this PR tested?
<!--
Describe what testings you have done. If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide UI screenshot, the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.