### PR TITLE
Expose Registry status code through RBAC layer

### DIFF
--- a/registry/access_control/api.py
+++ b/registry/access_control/api.py
@@ -1,11 +1,11 @@
 import json
 from typing import Optional
-from fastapi import APIRouter, Depends
 import requests
-from rbac.access import *
-from rbac.models import User
-from rbac.db_rbac import DbRBAC
+from fastapi import APIRouter, Depends, Response
 from rbac import config
+from rbac.access import *
+from rbac.db_rbac import DbRBAC
+from rbac.models import User
 
 router = APIRouter()
 rbac = DbRBAC()
@@ -13,99 +13,100 @@ registry_url = config.RBAC_REGISTRY_URL
 
 
 @router.get('/projects', name="Get a list of Project Names [No Auth Required]")
-async def get_projects() -> list[str]:
-    response = check(requests.get(url=f"{registry_url}/projects")).content.decode('utf-8')
-    return json.loads(response)
+async def get_projects(response: Response) -> list[str]:
+    response.status_code, res = check(
+        requests.get(url=f"{registry_url}/projects"))
+    return res
 
 
 @router.get('/projects/{project}', name="Get My Project [Read Access Required]")
-async def get_project(project: str, access: UserAccess  = Depends(project_read_access)):
-    response = check(requests.get(url=f"{registry_url}/projects/{project}",
-                            headers=get_api_header(access.user_name))).content.decode('utf-8')
-    return json.loads(response)
+async def get_project(project: str, response: Response, access: UserAccess = Depends(project_read_access)):
+    response.status_code, res = check(requests.get(url=f"{registry_url}/projects/{project}",
+                                                   headers=get_api_header(access.user_name)))
+    return res
 
 
 @router.get("/projects/{project}/datasources", name="Get data sources of my project [Read Access Required]")
-def get_project_datasources(project: str, access: UserAccess = Depends(project_read_access)) -> list:
-    response = check(requests.get(url=f"{registry_url}/projects/{project}/datasources",
-                            headers=get_api_header(access.user_name))).content.decode('utf-8')
-    return json.loads(response)
+def get_project_datasources(project: str, response: Response, access: UserAccess = Depends(project_read_access)) -> list:
+    response.status_code, res = check(requests.get(url=f"{registry_url}/projects/{project}/datasources",
+                                                   headers=get_api_header(access.user_name)))
+    return res
 
 
 @router.get("/projects/{project}/datasources/{datasource}", name="Get a single data source by datasource Id [Read Access Required]")
-def get_project_datasource(project: str, datasource: str, requestor: UserAccess = Depends(project_read_access)) -> list:
-    response = check(requests.get(url=f"{registry_url}/projects/{project}/datasources/{datasource}",
-                            headers=get_api_header(requestor.user_name))).content.decode('utf-8')
-    return json.loads(response)
+def get_project_datasource(project: str, datasource: str, response: Response, requestor: UserAccess = Depends(project_read_access)) -> list:
+    response.status_code, res = check(requests.get(url=f"{registry_url}/projects/{project}/datasources/{datasource}",
+                                                   headers=get_api_header(requestor.user_name)))
+    return res
 
 
 @router.get("/projects/{project}/features", name="Get features under my project [Read Access Required]")
-def get_project_features(project: str, keyword: Optional[str] = None, access: UserAccess = Depends(project_read_access)) -> list:
-    response = check(requests.get(url=f"{registry_url}/projects/{project}/features",
-                            headers=get_api_header(access.user_name))).content.decode('utf-8')
-    return json.loads(response)
+def get_project_features(project: str, response: Response, keyword: Optional[str] = None, access: UserAccess = Depends(project_read_access)) -> list:
+    response.status_code, res = check(requests.get(url=f"{registry_url}/projects/{project}/features",
+                                                   headers=get_api_header(access.user_name)))
+    return res
 
 
 @router.get("/features/{feature}", name="Get a single feature by feature Id [Read Access Required]")
-def get_feature(feature: str, requestor: User = Depends(get_user)) -> dict:
-    response = check(requests.get(url=f"{registry_url}/features/{feature}",
-                            headers=get_api_header(requestor.username))).content.decode('utf-8')
-    ret = json.loads(response)
+def get_feature(feature: str, response: Response, requestor: User = Depends(get_user)) -> dict:
+    response.status_code, res = check(requests.get(url=f"{registry_url}/features/{feature}",
+                                                   headers=get_api_header(requestor.username)))
 
-    feature_qualifiedName = ret['attributes']['qualifiedName']
+    feature_qualifiedName = res['attributes']['qualifiedName']
     validate_project_access_for_feature(
         feature_qualifiedName, requestor, AccessType.READ)
-    return ret
+    return res
 
 
 @router.get("/features/{feature}/lineage", name="Get Feature Lineage [Read Access Required]")
-def get_feature_lineage(feature: str, requestor: User = Depends(get_user)) -> dict:
-    response = check(requests.get(url=f"{registry_url}/features/{feature}/lineage",
-                            headers=get_api_header(requestor.username))).content.decode('utf-8')
-    ret = json.loads(response)
+def get_feature_lineage(feature: str, response: Response, requestor: User = Depends(get_user)) -> dict:
+    response.status_code, res = check(requests.get(url=f"{registry_url}/features/{feature}/lineage",
+                                                   headers=get_api_header(requestor.username)))
 
-    feature_qualifiedName = ret['guidEntityMap'][feature]['attributes']['qualifiedName']
+    feature_qualifiedName = res['guidEntityMap'][feature]['attributes']['qualifiedName']
     validate_project_access_for_feature(
         feature_qualifiedName, requestor, AccessType.READ)
-    return ret
+    return res
 
 
 @router.post("/projects", name="Create new project with definition [Auth Required]")
-def new_project(definition: dict, requestor: User = Depends(get_user)) -> dict:
+def new_project(definition: dict, response: Response, requestor: User = Depends(get_user)) -> dict:
     rbac.init_userrole(requestor.username, definition["name"])
-    response = check(requests.post(url=f"{registry_url}/projects", json=definition,
-                             headers=get_api_header(requestor.username))).content.decode('utf-8')
-    return json.loads(response)
+    response.status_code, res = check(requests.post(url=f"{registry_url}/projects", json=definition,
+                                                    headers=get_api_header(requestor.username)))
+    return res
 
 
 @router.post("/projects/{project}/datasources", name="Create new data source of my project [Write Access Required]")
-def new_project_datasource(project: str, definition: dict, access: UserAccess = Depends(project_write_access)) -> dict:
-    response = check(requests.post(url=f"{registry_url}/projects/{project}/datasources", json=definition, headers=get_api_header(
-        access.user_name))).content.decode('utf-8')
-    return json.loads(response)
+def new_project_datasource(project: str, definition: dict, response: Response, access: UserAccess = Depends(project_write_access)) -> dict:
+    response.status_code, res = check(requests.post(url=f"{registry_url}/projects/{project}/datasources", json=definition, headers=get_api_header(
+        access.user_name)))
+    return res
 
 
 @router.post("/projects/{project}/anchors", name="Create new anchors of my project [Write Access Required]")
-def new_project_anchor(project: str, definition: dict, access: UserAccess = Depends(project_write_access)) -> dict:
-    response = check(requests.post(url=f"{registry_url}/projects/{project}/anchors", json=definition, headers=get_api_header(
-        access.user_name))).content.decode('utf-8')
-    return json.loads(response)
+def new_project_anchor(project: str, definition: dict, response: Response, access: UserAccess = Depends(project_write_access)) -> dict:
+    response.status_code, res = check(requests.post(url=f"{registry_url}/projects/{project}/anchors", json=definition, headers=get_api_header(
+        access.user_name)))
+    return res
 
 
 @router.post("/projects/{project}/anchors/{anchor}/features", name="Create new anchor features of my project [Write Access Required]")
-def new_project_anchor_feature(project: str, anchor: str, definition: dict, access: UserAccess = Depends(project_write_access)) -> dict:
-    response = check(requests.post(url=f"{registry_url}/projects/{project}/anchors/{anchor}/features", json=definition, headers=get_api_header(
-        access.user_name))).content.decode('utf-8')
-    return json.loads(response)
+def new_project_anchor_feature(project: str, anchor: str, definition: dict, response: Response, access: UserAccess = Depends(project_write_access)) -> dict:
+    response.status_code, res = check(requests.post(url=f"{registry_url}/projects/{project}/anchors/{anchor}/features", json=definition, headers=get_api_header(
+        access.user_name)))
+    return res
 
 
 @router.post("/projects/{project}/derivedfeatures", name="Create new derived features of my project [Write Access Required]")
-def new_project_derived_feature(project: str, definition: dict, access: UserAccess = Depends(project_write_access)) -> dict:
-    response = check(requests.post(url=f"{registry_url}/projects/{project}/derivedfeatures",
-                             json=definition, headers=get_api_header(access.user_name))).content.decode('utf-8')
-    return json.loads(response)
+def new_project_derived_feature(project: str, definition: dict, response: Response, access: UserAccess = Depends(project_write_access)) -> dict:
+    response.status_code, res = check(requests.post(url=f"{registry_url}/projects/{project}/derivedfeatures",
+                                                    json=definition, headers=get_api_header(access.user_name)))
+    return res
 
 # Below are access control management APIs
+
+
 @router.get("/userroles", name="List all active user role records [Project Manage Access Required]")
 def get_userroles(requestor: User = Depends(get_user)) -> list:
     return rbac.list_userroles(requestor.username)
@@ -117,15 +118,9 @@ def add_userrole(project: str, user: str, role: str, reason: str, access: UserAc
 
 
 @router.delete("/users/{user}/userroles/delete", name="Delete a user role [Project Manage Access Required]")
-def delete_userrole(user: str, role: str, reason: str, access: UserAccess= Depends(project_manage_access)):
+def delete_userrole(user: str, role: str, reason: str, access: UserAccess = Depends(project_manage_access)):
     return rbac.delete_userrole(access.project_name, user, role, reason, access.user_name)
 
-class RegistryException(HTTPException):
-    def __init__(self, status_code, detail: Any = None) -> None:
-        super().__init__(status_code=status_code,
-                         detail=detail, headers={"WWW-Authenticate": "Bearer"})
 
 def check(r):
-    if not r.ok:
-        raise RegistryException(r.status_code, f"RBAC layer failed to call registry API, error is {r.text}")
-    return r
+    return r.status_code, json.loads(r.content.decode("utf-8"))

--- a/registry/access_control/api.py
+++ b/registry/access_control/api.py
@@ -14,43 +14,42 @@ registry_url = config.RBAC_REGISTRY_URL
 
 @router.get('/projects', name="Get a list of Project Names [No Auth Required]")
 async def get_projects() -> list[str]:
-    response = requests.get(
-        url=f"{registry_url}/projects").content.decode('utf-8')
+    response = check(requests.get(url=f"{registry_url}/projects")).content.decode('utf-8')
     return json.loads(response)
 
 
 @router.get('/projects/{project}', name="Get My Project [Read Access Required]")
 async def get_project(project: str, access: UserAccess  = Depends(project_read_access)):
-    response = requests.get(url=f"{registry_url}/projects/{project}",
-                            headers=get_api_header(access.user_name)).content.decode('utf-8')
+    response = check(requests.get(url=f"{registry_url}/projects/{project}",
+                            headers=get_api_header(access.user_name))).content.decode('utf-8')
     return json.loads(response)
 
 
 @router.get("/projects/{project}/datasources", name="Get data sources of my project [Read Access Required]")
 def get_project_datasources(project: str, access: UserAccess = Depends(project_read_access)) -> list:
-    response = requests.get(url=f"{registry_url}/projects/{project}/datasources",
-                            headers=get_api_header(access.user_name)).content.decode('utf-8')
+    response = check(requests.get(url=f"{registry_url}/projects/{project}/datasources",
+                            headers=get_api_header(access.user_name))).content.decode('utf-8')
     return json.loads(response)
 
 
 @router.get("/projects/{project}/datasources/{datasource}", name="Get a single data source by datasource Id [Read Access Required]")
 def get_project_datasource(project: str, datasource: str, requestor: UserAccess = Depends(project_read_access)) -> list:
-    response = requests.get(url=f"{registry_url}/projects/{project}/datasources/{datasource}",
-                            headers=get_api_header(requestor.user_name)).content.decode('utf-8')
+    response = check(requests.get(url=f"{registry_url}/projects/{project}/datasources/{datasource}",
+                            headers=get_api_header(requestor.user_name))).content.decode('utf-8')
     return json.loads(response)
 
 
 @router.get("/projects/{project}/features", name="Get features under my project [Read Access Required]")
 def get_project_features(project: str, keyword: Optional[str] = None, access: UserAccess = Depends(project_read_access)) -> list:
-    response = requests.get(url=f"{registry_url}/projects/{project}/features",
-                            headers=get_api_header(access.user_name)).content.decode('utf-8')
+    response = check(requests.get(url=f"{registry_url}/projects/{project}/features",
+                            headers=get_api_header(access.user_name))).content.decode('utf-8')
     return json.loads(response)
 
 
 @router.get("/features/{feature}", name="Get a single feature by feature Id [Read Access Required]")
 def get_feature(feature: str, requestor: User = Depends(get_user)) -> dict:
-    response = requests.get(url=f"{registry_url}/features/{feature}",
-                            headers=get_api_header(requestor.username)).content.decode('utf-8')
+    response = check(requests.get(url=f"{registry_url}/features/{feature}",
+                            headers=get_api_header(requestor.username))).content.decode('utf-8')
     ret = json.loads(response)
 
     feature_qualifiedName = ret['attributes']['qualifiedName']
@@ -61,8 +60,8 @@ def get_feature(feature: str, requestor: User = Depends(get_user)) -> dict:
 
 @router.get("/features/{feature}/lineage", name="Get Feature Lineage [Read Access Required]")
 def get_feature_lineage(feature: str, requestor: User = Depends(get_user)) -> dict:
-    response = requests.get(url=f"{registry_url}/features/{feature}/lineage",
-                            headers=get_api_header(requestor.username)).content.decode('utf-8')
+    response = check(requests.get(url=f"{registry_url}/features/{feature}/lineage",
+                            headers=get_api_header(requestor.username))).content.decode('utf-8')
     ret = json.loads(response)
 
     feature_qualifiedName = ret['guidEntityMap'][feature]['attributes']['qualifiedName']
@@ -74,36 +73,36 @@ def get_feature_lineage(feature: str, requestor: User = Depends(get_user)) -> di
 @router.post("/projects", name="Create new project with definition [Auth Required]")
 def new_project(definition: dict, requestor: User = Depends(get_user)) -> dict:
     rbac.init_userrole(requestor.username, definition["name"])
-    response = requests.post(url=f"{registry_url}/projects", json=definition,
-                             headers=get_api_header(requestor.username)).content.decode('utf-8')
+    response = check(requests.post(url=f"{registry_url}/projects", json=definition,
+                             headers=get_api_header(requestor.username))).content.decode('utf-8')
     return json.loads(response)
 
 
 @router.post("/projects/{project}/datasources", name="Create new data source of my project [Write Access Required]")
 def new_project_datasource(project: str, definition: dict, access: UserAccess = Depends(project_write_access)) -> dict:
-    response = requests.post(url=f"{registry_url}/projects/{project}/datasources", json=definition, headers=get_api_header(
-        access.user_name)).content.decode('utf-8')
+    response = check(requests.post(url=f"{registry_url}/projects/{project}/datasources", json=definition, headers=get_api_header(
+        access.user_name))).content.decode('utf-8')
     return json.loads(response)
 
 
 @router.post("/projects/{project}/anchors", name="Create new anchors of my project [Write Access Required]")
 def new_project_anchor(project: str, definition: dict, access: UserAccess = Depends(project_write_access)) -> dict:
-    response = requests.post(url=f"{registry_url}/projects/{project}/anchors", json=definition, headers=get_api_header(
-        access.user_name)).content.decode('utf-8')
+    response = check(requests.post(url=f"{registry_url}/projects/{project}/anchors", json=definition, headers=get_api_header(
+        access.user_name))).content.decode('utf-8')
     return json.loads(response)
 
 
 @router.post("/projects/{project}/anchors/{anchor}/features", name="Create new anchor features of my project [Write Access Required]")
 def new_project_anchor_feature(project: str, anchor: str, definition: dict, access: UserAccess = Depends(project_write_access)) -> dict:
-    response = requests.post(url=f"{registry_url}/projects/{project}/anchors/{anchor}/features", json=definition, headers=get_api_header(
-        access.user_name)).content.decode('utf-8')
+    response = check(requests.post(url=f"{registry_url}/projects/{project}/anchors/{anchor}/features", json=definition, headers=get_api_header(
+        access.user_name))).content.decode('utf-8')
     return json.loads(response)
 
 
 @router.post("/projects/{project}/derivedfeatures", name="Create new derived features of my project [Write Access Required]")
 def new_project_derived_feature(project: str, definition: dict, access: UserAccess = Depends(project_write_access)) -> dict:
-    response = requests.post(url=f"{registry_url}/projects/{project}/derivedfeatures",
-                             json=definition, headers=get_api_header(access.user_name)).content.decode('utf-8')
+    response = check(requests.post(url=f"{registry_url}/projects/{project}/derivedfeatures",
+                             json=definition, headers=get_api_header(access.user_name))).content.decode('utf-8')
     return json.loads(response)
 
 # Below are access control management APIs
@@ -120,3 +119,13 @@ def add_userrole(project: str, user: str, role: str, reason: str, access: UserAc
 @router.delete("/users/{user}/userroles/delete", name="Delete a user role [Project Manage Access Required]")
 def delete_userrole(user: str, role: str, reason: str, access: UserAccess= Depends(project_manage_access)):
     return rbac.delete_userrole(access.project_name, user, role, reason, access.user_name)
+
+class RegistryException(Exception):
+    def __init__(self, status_code, detail: Any = None) -> None:
+        super().__init__(status_code=status_code,
+                         detail=detail, headers={"WWW-Authenticate": "Bearer"})
+
+def check(r):
+    if not r.ok:
+        raise RegistryException(r.status_code, f"RBAC layer failed to call registry API, error is {r.text}")
+    return r

--- a/registry/access_control/api.py
+++ b/registry/access_control/api.py
@@ -120,7 +120,7 @@ def add_userrole(project: str, user: str, role: str, reason: str, access: UserAc
 def delete_userrole(user: str, role: str, reason: str, access: UserAccess= Depends(project_manage_access)):
     return rbac.delete_userrole(access.project_name, user, role, reason, access.user_name)
 
-class RegistryException(Exception):
+class RegistryException(HTTPException):
     def __init__(self, status_code, detail: Any = None) -> None:
         super().__init__(status_code=status_code,
                          detail=detail, headers={"WWW-Authenticate": "Bearer"})


### PR DESCRIPTION
Signed-off-by: Yuqing Wei <weiyuqing021@outlook.com>

## Description
<!--
Hey! Thank you for the contribution! Please go through https://github.com/feathr-ai/feathr/blob/main/docs/dev_guide/pull_request_guideline.md for more information.

Describe what changes to make and why you are making these changes.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Resolves #865

## How was this PR tested?
<!--
Describe what testings you have done. If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

Tested in local:
<img width="684" alt="image" src="https://user-images.githubusercontent.com/26561033/202492482-79a28918-d8cf-4c7e-a7c9-3168d13b1eb9.png">
Now backend registry failure status_code can be exposed. 


## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide UI screenshot, the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.