### PR TITLE
Fix installation error in some environments

### DIFF
--- a/feathr_project/feathr/version.py
+++ b/feathr_project/feathr/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.9.0-rc3"
+__version__ = "0.9.0-rc4"
 
 def get_version():
     return __version__

--- a/feathr_project/setup.py
+++ b/feathr_project/setup.py
@@ -5,8 +5,14 @@ from pathlib import Path
 
 # Use the README.md from /docs
 root_path = Path(__file__).resolve().parent.parent
-long_description = (root_path / "docs/README.md").read_text(encoding="utf8")
 
+readme_path = root_path / "docs/README.md"
+if readme_path.exists():
+    long_description = readme_path.read_text(encoding="utf8")
+else:
+    # In some build environments (specifically in conda), we may not have the README file
+    # readily available. In these cases, just set long_description to the URL of README.md.
+    long_description = "See https://github.com/feathr-ai/feathr/blob/main/docs/README.md"
 try:
     exec(open("feathr/version.py").read())
 except IOError:


### PR DESCRIPTION
## Description 
Set long_description in setup.py to the URL of README.md when the README.md cannot be found to avoid installation error. This happens in some build environments (specifically in conda). See similar handling [here](https://github.com/streamlit/streamlit/blob/df1718b6d7ebb097c0432cdcb82eddc9d796d824/lib/setup.py#L89)

## Does this PR introduce any user-facing changes?
No