### PR TITLE
Add a new method for standard DotProduct in addition to cosine similarity

### DIFF
--- a/feathr-impl/src/main/java/com/linkedin/feathr/common/util/MvelContextUDFs.java
+++ b/feathr-impl/src/main/java/com/linkedin/feathr/common/util/MvelContextUDFs.java
@@ -365,6 +365,31 @@ public class MvelContextUDFs {
   }
 
   /**
+   * Returns a standard dotProduct of two vector objects.
+   * Use {@link MvelContextUDFs#cosineSimilarity(Object, Object)} for normalized dot-product.
+   */
+  @ExportToMvel
+  public static Double dotProduct(Object obj1, Object obj2) {
+    if (obj1 == null || obj2 == null) {
+      return null;
+    }
+    Map<String, Float> mapA = CoercionUtils.coerceToVector(obj1);
+    Map<String, Float> mapB = CoercionUtils.coerceToVector(obj2);
+    double dotProduct = 0;
+
+    for (Map.Entry<String, Float> entry : mapA.entrySet()) {
+      String k = entry.getKey();
+      float valA = entry.getValue();
+      Float valB = mapB.get(k);
+      if (valB != null) {
+        dotProduct += ((double) valA * valB);
+      }
+    }
+
+    return dotProduct;
+  }
+
+  /**
    * convert input to lower case string
    * @param input input string
    * @return lower case input

--- a/feathr-impl/src/test/java/com/linkedin/feathr/offline/TestMvelContext.java
+++ b/feathr-impl/src/test/java/com/linkedin/feathr/offline/TestMvelContext.java
@@ -30,4 +30,24 @@ public class TestMvelContext extends TestNGSuite {
     categoricalOutput2.clear();
     assertEquals(cosineSimilarity(categoricalOutput1, categoricalOutput2), 0.0F);
   }
+
+  @Test
+  public void testDotProduct() {
+    // Test basic dot product calculation
+    Map<String, Float> categoricalOutput1 = new HashMap<>();
+    categoricalOutput1.put("A", 1F);
+    categoricalOutput1.put("B", 1F);
+
+    Map<String, Float> categoricalOutput2 = new HashMap<>();
+    categoricalOutput2.put("B", 1F);
+    categoricalOutput2.put("C", 1F);
+
+    assertEquals(dotProduct(categoricalOutput1, categoricalOutput2), 1.0D);
+
+    // Test dot product of zero vectors
+    categoricalOutput1.clear();
+    assertEquals(dotProduct(categoricalOutput1, categoricalOutput2), 0.0D);
+    categoricalOutput2.clear();
+    assertEquals(dotProduct(categoricalOutput1, categoricalOutput2), 0.0D);
+  }
 }


### PR DESCRIPTION
## Description

While we do support cosine similarity which produces a standardized score between 0-1, some users have requested support for a standard dotProduct where standardization of similarity score is not desirable.

## How was this PR tested?

Added unit test for new static method. ./gradlew build

## Does this PR introduce any user-facing changes?

Yes, users will be able to calculate dotProduct like we currently support cosine similarity via mvel.