### PR TITLE
add KeyError for key and feature type

### DIFF
--- a/feathr_project/feathr/definition/feature.py
+++ b/feathr_project/feathr/definition/feature.py
@@ -30,6 +30,11 @@ class FeatureBase(HoconConvertible):
                  registry_tags: Optional[Dict[str, str]] = None,
                  ):
         FeatureBase.validate_feature_name(name)
+
+        # Validate the feature type
+        if not isinstance(feature_type, FeatureType):
+            raise KeyError(f'Feature type must be a FeatureType class, like INT32, but got {feature_type}')
+
         self.name = name
         self.feature_type = feature_type
         self.registry_tags=registry_tags

--- a/feathr_project/feathr/definition/typed_key.py
+++ b/feathr_project/feathr/definition/typed_key.py
@@ -20,6 +20,10 @@ class TypedKey:
                  full_name: Optional[str] = None,
                  description: Optional[str] = None,
                  key_column_alias: Optional[str] = None) -> None:
+        # Validate the key_column type
+        if not isinstance(key_column_type, ValueType):
+            raise KeyError(f'key_column_type must be a ValueType, like Value.INT32, but got {key_column_type}')
+        
         self.key_column = key_column
         self.key_column_type = key_column_type
         self.full_name = full_name

--- a/feathr_project/test/unit/test_dtype.py
+++ b/feathr_project/test/unit/test_dtype.py
@@ -1,0 +1,24 @@
+import pytest
+from feathr import Feature, TypedKey, ValueType, INT32
+
+
+def test_key_type():
+    key = TypedKey(key_column="key", key_column_type=ValueType.INT32)
+    assert key.key_column_type == ValueType.INT32
+
+    with pytest.raises(KeyError):
+        key = TypedKey(key_column="key", key_column_type=INT32)
+
+def test_feature_type():
+    key = TypedKey(key_column="key", key_column_type=ValueType.INT32)
+
+    feature = Feature(name="name",
+                      key=key,
+                      feature_type=INT32)
+    
+    assert feature.feature_type == INT32
+
+    with pytest.raises(KeyError):
+        feature = Feature(name="name",
+                          key=key,
+                          feature_type=ValueType.INT32)


### PR DESCRIPTION
Signed-off-by: Yuqing Wei <weiyuqing021@outlook.com>

## Description
<!--
Hey! Thank you for the contribution! Please go through https://github.com/feathr-ai/feathr/blob/main/docs/dev_guide/pull_request_guideline.md for more information.

Describe what changes to make and why you are making these changes.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Resolves #766 

## How was this PR tested?
<!--
Describe what testings you have done. If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

Test `test_dtype.py` added under unit folder with 2 functions:
- test_key_type
- test_feature_type

<img width="846" alt="image" src="https://user-images.githubusercontent.com/26561033/203467580-04a56491-137b-41ad-839b-0db410257a45.png">


## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide UI screenshot, the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to clarify your proposed changes.

User will get KeyError if the type of Key or Feature is not correct. 