### PR TITLE
Add 'format' arg to get_result_df

### DIFF
--- a/feathr_project/feathr/utils/job_utils.py
+++ b/feathr_project/feathr/utils/job_utils.py
@@ -62,6 +62,7 @@ def get_result_spark_df(
 def get_result_df(
     client: FeathrClient,
     data_format: str = None,
+    format: str = None,
     res_url: str = None,
     local_cache_path: str = None,
     spark: SparkSession = None,
@@ -72,6 +73,7 @@ def get_result_df(
         client: Feathr client
         data_format: Format to read the downloaded files. Currently support `parquet`, `delta`, `avro`, and `csv`.
             Default to use client's job tags if exists.
+        format: An alias for `data_format` (for backward compatibility).
         res_url: Result URL to download files from. Note that this will not block the job so you need to make sure
             the job is finished and the result URL contains actual data. Default to use client's job tags if exists.
         local_cache_path (optional): Specify the absolute download directory. if the user does not provide this,
@@ -82,6 +84,9 @@ def get_result_df(
     Returns:
         Either Spark or pandas DataFrame.
     """
+    if format is not None:
+        data_format = format
+
     if data_format is None:
         # May use data format from the job tags
         if client.get_job_tags() and client.get_job_tags().get(OUTPUT_FORMAT):

--- a/feathr_project/feathr/utils/job_utils.py
+++ b/feathr_project/feathr/utils/job_utils.py
@@ -31,7 +31,7 @@ def get_result_pandas_df(
     Returns:
         pandas DataFrame
     """
-    return get_result_df(client, data_format, res_url, local_cache_path)
+    return get_result_df(client=client, data_format=data_format, res_url=res_url, local_cache_path=local_cache_path)
 
 
 def get_result_spark_df(
@@ -56,7 +56,13 @@ def get_result_spark_df(
     Returns:
         Spark DataFrame
     """
-    return get_result_df(client, data_format, res_url, local_cache_path, spark=spark)
+    return get_result_df(
+        client=client,
+        data_format=data_format,
+        res_url=res_url,
+        local_cache_path=local_cache_path,
+        spark=spark,
+    )
 
 
 def get_result_df(

--- a/feathr_project/test/unit/utils/test_job_utils.py
+++ b/feathr_project/test/unit/utils/test_job_utils.py
@@ -26,7 +26,12 @@ def test__get_result_pandas_df(mocker: MockerFixture):
     res_url = "some_res_url"
     local_cache_path = "some_local_cache_path"
     get_result_pandas_df(client, data_format, res_url, local_cache_path)
-    mocked_get_result_df.assert_called_once_with(client, data_format, res_url, local_cache_path)
+    mocked_get_result_df.assert_called_once_with(
+        client=client,
+        data_format=data_format,
+        res_url=res_url,
+        local_cache_path=local_cache_path,
+    )
 
 
 def test__get_result_spark_df(mocker: MockerFixture):
@@ -38,7 +43,13 @@ def test__get_result_spark_df(mocker: MockerFixture):
     res_url = "some_res_url"
     local_cache_path = "some_local_cache_path"
     get_result_spark_df(spark, client, data_format, res_url, local_cache_path)
-    mocked_get_result_df.assert_called_once_with(client, data_format, res_url, local_cache_path, spark=spark)
+    mocked_get_result_df.assert_called_once_with(
+        client=client,
+        data_format=data_format,
+        res_url=res_url,
+        local_cache_path=local_cache_path,
+        spark=spark,
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Signed-off-by: Jun Ki Min <42475935+loomlike@users.noreply.github.com>

## Description
Add `format` arg back to `get_result_df` utility for backward compatibility

## How was this PR tested?
Unit-test

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide UI screenshot, the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to clarify your proposed changes.