### PR TITLE
Fix auto-tz casting bug

### DIFF
--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/transformation/FDSConversionUtils.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/transformation/FDSConversionUtils.scala
@@ -371,7 +371,7 @@ private[offline] object FDSConversionUtils {
     }
     // we need to sort arrays according to dimension array of the 1d sparse tensor, i.e. the first array
     val valType = targetType.asInstanceOf[StructType].fields(1).dataType.asInstanceOf[ArrayType].elementType
-    val indexArray = arrays(0).asInstanceOf[Array[Any]]
+    val indexArray = arrays(0).toArray
     val sortedArrays = if (indexArray.nonEmpty) {
       val firstElement = indexArray.head
       val sortedArrays = firstElement match {

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/SlidingWindowAggIntegTest.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/SlidingWindowAggIntegTest.scala
@@ -193,7 +193,7 @@ class SlidingWindowAggIntegTest extends FeathrIntegTest {
         |features: [
         |  {
         |    key: [mId],
-        |    featureList: ["aEmbedding"]
+        |    featureList: ["aEmbedding", "memberEmbeddingAutoTZ"]
         |  }
         |]
       """.stripMargin,
@@ -219,6 +219,17 @@ class SlidingWindowAggIntegTest extends FeathrIntegTest {
         |        aggregation: LATEST
         |        window: 3d
         |      }
+        |      memberEmbeddingAutoTZ: {
+        |        def: "embedding"
+        |        aggregation: LATEST
+        |        window: 3d
+        |        type: {
+        |          type: TENSOR
+        |          tensorCategory: SPARSE
+        |          dimensionType: [INT]
+        |          valType: FLOAT
+        |        }
+        |      }
         |    }
         |  }
         |}
@@ -229,6 +240,8 @@ class SlidingWindowAggIntegTest extends FeathrIntegTest {
 
     assertEquals(featureList.size, 2)
     assertEquals(featureList(0).getAs[Row]("aEmbedding"), mutable.WrappedArray.make(Array(5.5f, 5.8f)))
+    assertEquals(featureList(0).getAs[Row]("memberEmbeddingAutoTZ"),
+      TestUtils.build1dSparseTensorFDSRow(Array(0, 1), Array(5.5f, 5.8f)))
   }
 
   /**


### PR DESCRIPTION
## Description
Fix auto-tz casting bug. The original code was unable to handle primitive arrays, i.e. int[] and would throw an error Caused by: java.lang.ClassCastException: [I cannot be cast to [Ljava.lang.Object; when encountering int[]. This specifically can cause an issue when trying to use auto-tz to convert from an array of floats to 


     type: {
            type: TENSOR
            tensorCategory: SPARSE
            dimensionType: [INT]
            valType: FLOAT
          }

Changing it to use toArray resolves this issue.

## How was this PR tested?
Added a new test case within integ test

## Does this PR introduce any user-facing changes?
No