### PR TITLE
Fixing Bugs reported during oncall

### DIFF
--- a/docs/how-to-guides/azure_resource_provision.json
+++ b/docs/how-to-guides/azure_resource_provision.json
@@ -41,8 +41,8 @@
       "sqlAdminPassword": {
         "type": "SecureString",
         "metadata": {
-          "description": "Specify the password for SQL Database admin. Please note that the password can't contain semi colon (;) 
-          in the end as it conflicts with connection string delimiter"
+          "description": "Specify the password for SQL Database admin. Please note that the password can't contain semicolon (;) 
+          as it conflicts with connection string delimiter"
         }
       },
       "registryBackend": {

--- a/docs/how-to-guides/azure_resource_provision.json
+++ b/docs/how-to-guides/azure_resource_provision.json
@@ -35,13 +35,14 @@
       "sqlAdminUsername": {
         "type": "String",
         "metadata": {
-          "description": "Specifies the username for SQL Database admin"
+          "description": "Specify the username for SQL Database admin"
         }
       },
       "sqlAdminPassword": {
         "type": "SecureString",
         "metadata": {
-          "description": "Specifies the password for SQL Database admin"
+          "description": "Specify the password for SQL Database admin. Please note that the password can't contain semi colon (;) 
+          in the end as it conflicts with connection string delimiter"
         }
       },
       "registryBackend": {

--- a/docs/samples/azure_synapse/product_recommendation_demo.ipynb
+++ b/docs/samples/azure_synapse/product_recommendation_demo.ipynb
@@ -167,6 +167,13 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
+        "If you run into issues where Key vault or other resources are not found through notebook despite being there, make sure you are connected to the right subscription by running the command: 'az account show' and 'az account set --subscription <subscription_id>'"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
         "# 4. Prerequisite: Feathr Configuration\n",
         "\n",
         "### Setting the environment variables\n",

--- a/docs/samples/azure_synapse/product_recommendation_demo.ipynb
+++ b/docs/samples/azure_synapse/product_recommendation_demo.ipynb
@@ -37,8 +37,56 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## 2. Prerequisite: Login to Azure and Install Feathr\n",
-        "\n",
+        "## 2. Prerequisite: Install Feathr and it's dependencies and Login to Azure"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Install Feathr and dependencies to run this notebook. Normally you could run all the pip installs in one line, but when running this notebook in synapse, you may get some errors or blocks installing above packages in one cell. Hence installing them in different cells."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "%pip install -U feathr"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "%pip install -U azure-cli"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "%pip install -U pandavro"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "%pip install -U scikit-learn"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
         "Login to Azure with a device code (You will see instructions in the output once you execute the cell):"
       ]
     },
@@ -49,22 +97,6 @@
       "outputs": [],
       "source": [
         "! az login --use-device-code"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Install Feathr and dependencies to run this notebook."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "%pip install -U feathr pandavro scikit-learn"
       ]
     },
     {
@@ -101,6 +133,13 @@
         "from sklearn.model_selection import train_test_split\n",
         "from azure.identity import AzureCliCredential\n",
         "from azure.keyvault.secrets import SecretClient"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "If you meet errors like 'cannot import FeatherClient from feathr', it may be caused by incompatible version of 'aiohttp'. Please try to install/upgrade it by running: '%pip install aiohttp==3.8.3'"
       ]
     },
     {


### PR DESCRIPTION
## Description
This PR solves two minor bugs found during bugbash/oncall

1. TypeError: function() argument 'code' must be code, not str

from feathr import FeathrClient results in the above error.

This is caused because of package version mismatch, please run the following command to install 3.8.3 version of aiohttp package

%pip install -U aiohttp

user somehow had this version installed, which didnt work
aiohttp 3.7.4.post0 

2. Instructions to not have semi colon in SQL password

## How was this PR tested?
Notebook was tested e2e successfully.

## Does this PR introduce any user-facing changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.