### PR TITLE
Exclude pegasus data files explicitly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ jar {
     configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
   }
   exclude 'META-INF/*.RSA', 'META-INF/*.SF','META-INF/*.DSA'
+
+  // Explicitly exclude com/linkedin/data files from the final jar. They can cause issues in other downstream applications.
+  exclude 'com/linkedin/data/**'
   zip64 = true
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.10.3-rc6
+version=0.10.3-rc7
 SONATYPE_AUTOMATIC_RELEASE=true
 POM_ARTIFACT_ID=feathr_2.12


### PR DESCRIPTION
Explicitly exclude the pegasus data files from the build as this can cause issues in downstream applications.