### PR TITLE
publish fat jar in maven update action

### DIFF
--- a/.github/workflows/publish-to-maven.yml
+++ b/.github/workflows/publish-to-maven.yml
@@ -35,3 +35,21 @@ jobs:
           PGP_SECRET: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+
+    # Publish Released Fat Jar to Blob Storage 
+      - name: Gradle build
+        run: |
+          ./gradlew build
+          # remote folder for CI upload
+          echo "CI_SPARK_REMOTE_JAR_FOLDER=feathr_jar_release" >> $GITHUB_ENV
+          # get local jar name without path
+          echo "FEATHR_LOCAL_JAR_FULL_NAME_PATH=$(ls build/libs/*.jar)" >> $GITHUB_ENV
+      
+      - name: Azure Blob Storage Upload (Overwrite)
+        uses: fixpoint/azblob-upload-artifact@v4
+        with:
+          connection-string: ${{secrets.SPARK_JAR_BLOB_CONNECTION_STRING}}
+          name: ${{ env.CI_SPARK_REMOTE_JAR_FOLDER}}
+          path: ${{ env.FEATHR_LOCAL_JAR_FULL_NAME_PATH}}
+          container: ${{secrets.SPARK_JAR_BLOB_CONTAINER}}
+          cleanup: "true"


### PR DESCRIPTION
## Description
<!--
Hey! Thank you for the contribution! Please go through https://github.com/feathr-ai/feathr/blob/main/docs/dev_guide/pull_request_guideline.md for more information.

Describe what changes to make and why you are making these changes.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Resolves #934 

## How was this PR tested?
<!--
Describe what testings you have done. If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

Currently, the Github Action will write fat jar to the storage defined by "SPARK_JAR_BLOB_CONNECTION_STRING". To separate it from CI artifacts, we may need to create a new secret to store released jar blob connection string in the future. 
This PR only provide a trackable released Fat jar for reference. 

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide UI screenshot, the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.