### PR TITLE
fix numpy version conflict w/ pyspark

### DIFF
--- a/feathr_project/setup.py
+++ b/feathr_project/setup.py
@@ -85,6 +85,8 @@ setup(
         "avro<=1.11.1",
         "azure-storage-file-datalake<=12.5.0",
         "azure-synapse-spark<=0.7.0",
+        # Synapse's aiohttp package is old and does not work with Feathr. We pin to a newer version here.
+        "aiohttp==3.8.3",
         # fixing Azure Machine Learning authentication issue per https://stackoverflow.com/a/72262694/3193073
         "azure-identity>=1.8.0",
         "azure-keyvault-secrets<=4.6.0",

--- a/feathr_project/setup.py
+++ b/feathr_project/setup.py
@@ -35,8 +35,9 @@ extras_require=dict(
         "pytest-mock>=3.8.1",
     ],
     notebook=[
-        "jupyter==1.0.0",
-        "matplotlib==3.6.1",
+        "azure-cli==2.37.0",
+        "jupyter>=1.0.0",
+        "matplotlib>=3.6.1",
         "papermill>=2.1.2,<3",      # to test run notebooks
         "scrapbook>=0.5.0,<1.0.0",  # to scrap notebook outputs
         "scikit-learn",             # for notebook examples
@@ -63,7 +64,8 @@ setup(
         "click<=8.1.3",
         "py4j<=0.10.9.7",
         "loguru<=0.6.0",
-        "pandas<=1.5.0",
+        "pandas>=1.5.0",
+        "numpy<=1.20.3",  # pin numpy due to pyspark's deprecated np.bool access
         "redis<=4.4.0",
         "requests<=2.28.1",
         "tqdm<=4.64.1",
@@ -83,8 +85,6 @@ setup(
         "avro<=1.11.1",
         "azure-storage-file-datalake<=12.5.0",
         "azure-synapse-spark<=0.7.0",
-        # Synapse's aiohttp package is old and does not work with Feathr. We pin to a newer version here.
-        "aiohttp==3.8.3",
         # fixing Azure Machine Learning authentication issue per https://stackoverflow.com/a/72262694/3193073
         "azure-identity>=1.8.0",
         "azure-keyvault-secrets<=4.6.0",


### PR DESCRIPTION
Signed-off-by: Jun Ki Min <42475935+loomlike@users.noreply.github.com>

## Description
Latest numpy deprecated `np.bool` which conflicts with pyspark and pandas.
This PR pins the numpy version to use older one to resolve that. We can unpin later once pyspark resolves the issue.

## How was this PR tested?
<!--
Describe what testings you have done. If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Local installation and check if `np.bool` can be accessed.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide UI screenshot, the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.