### PR TITLE
[BUG] zsh: no matches found: feathr[notebook] during pip install feathr[notebook]

### DIFF
--- a/docs/samples/customer360/Customer360.ipynb
+++ b/docs/samples/customer360/Customer360.ipynb
@@ -150,7 +150,7 @@
          },
          "outputs": [],
          "source": [
-            "! pip install --force-reinstall git+https://github.com/feathr-ai/feathr.git@registry_fix#subdirectory=feathr_project pandavro scikit-learn"
+            "%pip install --force-reinstall git+https://github.com/feathr-ai/feathr.git@registry_fix#subdirectory=feathr_project pandavro scikit-learn"
          ]
       },
       {

--- a/docs/samples/databricks/databricks_quickstart_nyc_taxi_demo.ipynb
+++ b/docs/samples/databricks/databricks_quickstart_nyc_taxi_demo.ipynb
@@ -70,7 +70,7 @@
    },
    "outputs": [],
    "source": [
-    "# Install feathr from the latest codes in the repo. You may use `pip install "feathr[notebook]"` as well.\n",
+    "# Install feathr from the latest codes in the repo. You may use `pip install \"feathr[notebook]\"` as well.\n",
     "%pip install \"git+https://github.com/feathr-ai/feathr.git#subdirectory=feathr_project&egg=feathr[notebook]\""
    ]
   },

--- a/docs/samples/databricks/databricks_quickstart_nyc_taxi_demo.ipynb
+++ b/docs/samples/databricks/databricks_quickstart_nyc_taxi_demo.ipynb
@@ -70,8 +70,13 @@
    },
    "outputs": [],
    "source": [
+<<<<<<< Updated upstream
     "# Install feathr from the latest codes in the repo. You may use `pip install feathr[notebook]` as well.\n",
     "!pip install \"git+https://github.com/feathr-ai/feathr.git#subdirectory=feathr_project&egg=feathr[notebook]\""
+=======
+    "# Install feathr from the latest codes in the repo. You may use `pip install "feathr[notebook]"` as well.\n",
+    "%pip install \"git+https://github.com/feathr-ai/feathr.git#subdirectory=feathr_project&egg=feathr[notebook]\""
+>>>>>>> Stashed changes
    ]
   },
   {

--- a/docs/samples/feature_embedding.ipynb
+++ b/docs/samples/feature_embedding.ipynb
@@ -26,8 +26,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Install feathr from the latest codes in the repo. You may use `pip install "feathr[notebook]"` as well.\n",
-    "# %pip install \"git+https://github.com/feathr-ai/feathr.git#subdirectory=feathr_project&egg=feathr[notebook]\""
+    "# Install feathr from the latest codes in the repo. You may use `pip install \"feathr[notebook]\"` as well.\n",
+    "#%pip install \"git+https://github.com/feathr-ai/feathr.git#subdirectory=feathr_project&egg=feathr[notebook]\""
    ]
   },
   {

--- a/docs/samples/feature_embedding.ipynb
+++ b/docs/samples/feature_embedding.ipynb
@@ -26,8 +26,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
+<<<<<<< Updated upstream
     "# Install feathr from the latest codes in the repo. You may use `pip install feathr[notebook]` as well.\n",
     "# !pip install \"git+https://github.com/feathr-ai/feathr.git#subdirectory=feathr_project&egg=feathr[notebook]\""
+=======
+    "# Install feathr from the latest codes in the repo. You may use `pip install "feathr[notebook]"` as well.\n",
+    "# %pip install \"git+https://github.com/feathr-ai/feathr.git#subdirectory=feathr_project&egg=feathr[notebook]\""
+>>>>>>> Stashed changes
    ]
   },
   {

--- a/docs/samples/local/Untitled.ipynb
+++ b/docs/samples/local/Untitled.ipynb
@@ -1,6 +1,0 @@
-{
- "cells": [],
- "metadata": {},
- "nbformat": 4,
- "nbformat_minor": 5
-}

--- a/docs/samples/local/Untitled.ipynb
+++ b/docs/samples/local/Untitled.ipynb
@@ -1,0 +1,6 @@
+{
+ "cells": [],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/samples/nyc_taxi_demo.ipynb
+++ b/docs/samples/nyc_taxi_demo.ipynb
@@ -73,10 +73,10 @@
    "outputs": [],
    "source": [
     "# To install feathr from the latest codes in the repo:\n",
-    "# %pip install \"git+https://github.com/feathr-ai/feathr.git#subdirectory=feathr_project&egg=feathr[notebook]\" \n",
+    "#%pip install \"git+https://github.com/feathr-ai/feathr.git#subdirectory=feathr_project&egg=feathr[notebook]\" \n",
     "\n",
     "# To install the latest release:\n",
-    "# !pip install \"feathr[notebook]\""
+    "#%pip install \"feathr[notebook]\""
    ]
   },
   {

--- a/docs/samples/nyc_taxi_demo.ipynb
+++ b/docs/samples/nyc_taxi_demo.ipynb
@@ -76,7 +76,7 @@
     "# !pip install \"git+https://github.com/feathr-ai/feathr.git#subdirectory=feathr_project&egg=feathr[notebook]\" \n",
     "\n",
     "# To install the latest release:\n",
-    "# !pip install feathr[notebook] "
+    "# !pip install \"feathr[notebook]\""
    ]
   },
   {

--- a/docs/samples/product_recommendation_demo_advanced.ipynb
+++ b/docs/samples/product_recommendation_demo_advanced.ipynb
@@ -99,7 +99,7 @@
          "source": [
             "### Install Feathr python package and it's dependencies\n",
             "\n",
-            "Here, we install the package from the repository's main branch. To use the latest release, you may run `pip install "feathr[notebook]"` instead. If so, however, some of the new features in this notebook might not work."
+            "Here, we install the package from the repository's main branch. To use the latest release, you may run `pip install \"feathr[notebook]\"` instead. If so, however, some of the new features in this notebook might not work."
          ]
       },
       {
@@ -108,8 +108,8 @@
          "metadata": {},
          "outputs": [],
          "source": [
-            "# Uncomment and run this cell to install feathr from the latest codes in the repo. You may use `pip install "feathr[notebook]"` as well.\n",
-            "# %pip install \"git+https://github.com/feathr-ai/feathr.git#subdirectory=feathr_project&egg=feathr[notebook]\"  "
+            "# Uncomment and run this cell to install feathr from the latest codes in the repo. You may use `pip install \"feathr[notebook]\"` as well.\n",
+            "#%pip install \"git+https://github.com/feathr-ai/feathr.git#subdirectory=feathr_project&egg=feathr[notebook]\"  "
          ]
       },
       {

--- a/docs/samples/product_recommendation_demo_advanced.ipynb
+++ b/docs/samples/product_recommendation_demo_advanced.ipynb
@@ -99,7 +99,7 @@
          "source": [
             "### Install Feathr python package and it's dependencies\n",
             "\n",
-            "Here, we install the package from the repository's main branch. To use the latest release, you may run `pip install feathr[notebook]` instead. If so, however, some of the new features in this notebook might not work."
+            "Here, we install the package from the repository's main branch. To use the latest release, you may run `pip install "feathr[notebook]"` instead. If so, however, some of the new features in this notebook might not work."
          ]
       },
       {
@@ -108,8 +108,13 @@
          "metadata": {},
          "outputs": [],
          "source": [
+<<<<<<< Updated upstream
             "# Uncomment and run this cell to install feathr from the latest codes in the repo. You may use `pip install feathr[notebook]` as well.\n",
             "# !pip install \"git+https://github.com/feathr-ai/feathr.git#subdirectory=feathr_project&egg=feathr[notebook]\"  "
+=======
+            "# Uncomment and run this cell to install feathr from the latest codes in the repo. You may use `pip install "feathr[notebook]"` as well.\n",
+            "# %pip install \"git+https://github.com/feathr-ai/feathr.git#subdirectory=feathr_project&egg=feathr[notebook]\"  "
+>>>>>>> Stashed changes
          ]
       },
       {


### PR DESCRIPTION
## Description
<!--
Hey! Thank you for the contribution! Please go through https://github.com/feathr-ai/feathr/blob/main/docs/dev_guide/pull_request_guideline.md for more information.

Describe what changes to make and why you are making these changes.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Resolves [#960](https://github.com/feathr-ai/feathr/issues/960)

## How was this PR tested?
<!--
Describe what testings you have done. If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Change
```sh
pip install feathr[notebook]
```
to 
```sh
pip install "feathr[notebook]"
```

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide UI screenshot, the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.