### PR TITLE
Adding azure-cosmos-package to databricks spark config

### DIFF
--- a/.github/workflows/pull_request_push_test.yml
+++ b/.github/workflows/pull_request_push_test.yml
@@ -108,7 +108,7 @@ jobs:
           SPARK_CONFIG__SPARK_CLUSTER: databricks
           SPARK_CONFIG__DATABRICKS__WORKSPACE_INSTANCE_URL: ${{secrets.DATABRICKS_HOST}}
           DATABRICKS_WORKSPACE_TOKEN_VALUE: ${{secrets.DATABRICKS_WORKSPACE_TOKEN_VALUE}}
-          SPARK_CONFIG__DATABRICKS__CONFIG_TEMPLATE: '{"run_name":"FEATHR_FILL_IN","new_cluster":{"spark_version":"9.1.x-scala2.12","num_workers":1,"spark_conf":{"FEATHR_FILL_IN":"FEATHR_FILL_IN"},"instance_pool_id":"${{secrets.DATABRICKS_INSTANCE_POOL_ID}}"},"libraries":[{"jar":"FEATHR_FILL_IN"}],"spark_jar_task":{"main_class_name":"FEATHR_FILL_IN","parameters":["FEATHR_FILL_IN"]}}'
+          SPARK_CONFIG__DATABRICKS__CONFIG_TEMPLATE: '{"run_name":"FEATHR_FILL_IN","new_cluster":{"spark_version":"9.1.x-scala2.12","num_workers":1,"spark_conf":{"FEATHR_FILL_IN":"FEATHR_FILL_IN"},"instance_pool_id":"${{secrets.DATABRICKS_INSTANCE_POOL_ID}}"},"libraries":[{"maven": {"coordinates": "com.azure.cosmos.spark:azure-cosmos-spark_3-1_2-12:4.16.0"}}],"spark_jar_task":{"main_class_name":"FEATHR_FILL_IN","parameters":["FEATHR_FILL_IN"]}}'
           REDIS_PASSWORD: ${{secrets.REDIS_PASSWORD}}
           AZURE_CLIENT_ID: ${{secrets.AZURE_CLIENT_ID}}
           AZURE_TENANT_ID: ${{secrets.AZURE_TENANT_ID}}

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ dependencies {
   implementation 'net.snowflake:snowflake-jdbc:3.13.18'
   implementation 'net.snowflake:spark-snowflake_2.12:2.10.0-spark_3.2'
   provided 'com.microsoft.azure:azure-eventhubs-spark_2.12:2.3.21'
-  provided 'com.azure.cosmos.spark:azure-cosmos-spark_3-2_2-12:4.11.1'
+  implementation 'com.azure.cosmos.spark:azure-cosmos-spark_3-1_2-12:4.16.0'
   provided 'com.microsoft.sqlserver:mssql-jdbc:10.2.0.jre8'
   provided 'org.eclipse.jetty:jetty-util:9.3.24.v20180605'
   provided 'org.apache.kafka:kafka-clients:3.1.0'
@@ -130,6 +130,7 @@ project.ext.spec = [
         'avro' : "org.apache.avro:avro:1.10.2",
         "avroUtil": "com.linkedin.avroutil1:helper-all:0.2.100",
         "azure": "com.microsoft.azure:azure-eventhubs-spark_2.12:2.3.21",
+        "spark_cosmos": "com.azure.cosmos.spark:azure-cosmos-spark_3-1_2-12:4.16.0",
         'fastutil' : "it.unimi.dsi:fastutil:8.1.1",
         'mvel' : "org.mvel:mvel2:2.2.8.Final",
         'protobuf' : "com.google.protobuf:protobuf-java:2.6.1",

--- a/feathr-impl/build.gradle
+++ b/feathr-impl/build.gradle
@@ -48,6 +48,7 @@ dependencies {
   implementation spec.product.jackson.dataformat_hocon
   implementation spec.product.jackson.jackson_core
   implementation spec.product.spark_redis
+  implementation spec.product.spark_cosmos
   implementation spec.product.fastutil
   implementation spec.product.hadoop.mapreduce_client_core
   implementation spec.product.mvel
@@ -77,6 +78,7 @@ dependencies {
 
   testImplementation spec.product.equalsverifier
   testImplementation spec.product.spark.spark_catalyst
+  testImplementation spec.product.spark_cosmos
   testImplementation spec.product.mockito
   testImplementation spec.product.scala.scalatest
   testImplementation spec.product.testing


### PR DESCRIPTION
## Adding azue.spark.cosmos package to spark config so it is available to databricks test cluster.


## Does this PR introduce any user-facing changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.