### PR TITLE
Fix maven publish workflow always skip Gradle publish

### DIFF
--- a/.github/workflows/publish-to-maven.yml
+++ b/.github/workflows/publish-to-maven.yml
@@ -28,7 +28,6 @@ jobs:
     # CI release command defaults to publishSigned
     # Sonatype release command defaults to sonaTypeBundleRelease
       - name: Gradle publish
-        if: startsWith(github.head_ref, 'releases/v')
         run: gradle clean publish
         env:
           PGP_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}


### PR DESCRIPTION
Signed-off-by: Yuqing Wei <weiyuqing021@outlook.com>

## Description
<!--
Hey! Thank you for the contribution! Please go through https://github.com/feathr-ai/feathr/blob/main/docs/dev_guide/pull_request_guideline.md for more information.

Describe what changes to make and why you are making these changes.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Currently Gradle Publish step will be skipped in standard release workflow.
remove the "if" statement in this workflow as a temp hot fix and see if it unblocks the issue. 

## How was this PR tested?
<!--
Describe what testings you have done. If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide UI screenshot, the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.