### PR TITLE
Lock python deps versions in sql registry

### DIFF
--- a/registry/sql-registry/requirements.txt
+++ b/registry/sql-registry/requirements.txt
@@ -1,6 +1,5 @@
-Cython
-pydantic 
+Cython==0.29.33
 pymssql==2.2.7
 fastapi==0.88.0
 uvicorn==0.20.0
-sqlalchemy
+sqlalchemy==1.4.46


### PR DESCRIPTION
## Description
<!--
Hey! Thank you for the contribution! Please go through https://github.com/feathr-ai/feathr/blob/main/docs/dev_guide/pull_request_guideline.md for more information.

Describe what changes to make and why you are making these changes.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR locks pip version for a few recent new deps
- cython: according to @enya-yx , this is required for sql registry to work on her dev environment, use latest version
- pydantic: removed, this is an indirect dep consumed by fastapi.
- sqlalchemy: this is newly added by @xiaoyongzhu for sandbox support, use latest version.

## How was this PR tested?
<!--
Describe what testings you have done. If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide UI screenshot, the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.