### PR TITLE
Updating automated maven publish workflow to work with gradle creds

### DIFF
--- a/.github/workflows/publish-to-maven.yml
+++ b/.github/workflows/publish-to-maven.yml
@@ -27,17 +27,20 @@ jobs:
 
     # CI release command defaults to publishSigned
     # Sonatype release command defaults to sonaTypeBundleRelease
-      - name: Gradle publish
-        run: gradle clean publish
+    # Changing env names as documented here - https://vanniktech.github.io/gradle-maven-publish-plugin/central/#secrets
+      - name: Gradle Build and Publish to Maven central
+        run: |
+          ./gradlew publish
+          ./gradlew closeAndReleaseRepository
         env:
-          PGP_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
 
     # Publish Released Fat Jar to Blob Storage 
       - name: Gradle build
-        run: |
+        run: |  
           ./gradlew build
           # remote folder for CI upload
           echo "CI_SPARK_REMOTE_JAR_FOLDER=feathr_jar_release" >> $GITHUB_ENV


### PR DESCRIPTION

## Description
The gradle plugin being used to build and publish jar to maven central requires that credentials be passed a certain way.
As documented here- https://vanniktech.github.io/gradle-maven-publish-plugin/central/#secrets

## How was this PR tested?
Will Test it as part of PR workflow.

## Does this PR introduce any user-facing changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.