### PR TITLE
Fixing Maven Automated Publish

### DIFF
--- a/.github/workflows/publish-to-maven.yml
+++ b/.github/workflows/publish-to-maven.yml
@@ -27,17 +27,20 @@ jobs:
 
     # CI release command defaults to publishSigned
     # Sonatype release command defaults to sonaTypeBundleRelease
-      - name: Gradle publish
-        run: gradle clean publish
+    # Changing env names as documented here - https://vanniktech.github.io/gradle-maven-publish-plugin/central/#secrets
+      - name: Gradle Build and Publish to Maven central
+        run: |
+          ./gradlew publish
+          ./gradlew closeAndReleaseRepository
         env:
-          PGP_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
 
     # Publish Released Fat Jar to Blob Storage 
       - name: Gradle build
-        run: |
+        run: |  
           ./gradlew build
           # remote folder for CI upload
           echo "CI_SPARK_REMOTE_JAR_FOLDER=feathr_jar_release" >> $GITHUB_ENV

--- a/.github/workflows/publish-to-maven.yml
+++ b/.github/workflows/publish-to-maven.yml
@@ -20,10 +20,10 @@ jobs:
           java-version: "8"
           distribution: "temurin"
           server-id: ossrh
-          server-username: SONATYPE_USERNAME
-          server-password: SONATYPE_PASSWORD
+          server-username: ORG_GRADLE_PROJECT_mavenCentralUsername
+          server-password: ORG_GRADLE_PROJECT_mavenCentralPassword
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          gpg-passphrase: PGP_PASSPHRASE
+          gpg-passphrase: ORG_GRADLE_PROJECT_signingInMemoryKeyPassword
 
     # CI release command defaults to publishSigned
     # Sonatype release command defaults to sonaTypeBundleRelease


### PR DESCRIPTION
## Description
Fixed the issue where the automated maven publish was not working, the reason was the variable names used by the publish plugin is named differently.

Verified the change in my personal fork here - https://github.com/jainr/feathr/actions/runs/3945949780/jobs/6753289258
Note: The pipeline failed because there is an issue in subsequent task which I am looking at with @Yuqing-cat but maven publishing works.

## How was this PR tested?
https://github.com/jainr/feathr/actions/runs/3945949780/jobs/6753289258

## Does this PR introduce any user-facing changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.