### PR TITLE
Publish Fat Jar to Blob Storage Steps Decouple and Fix

### DIFF
--- a/.github/workflows/publish-fat-jar.yml
+++ b/.github/workflows/publish-fat-jar.yml
@@ -1,0 +1,44 @@
+name: Publish Fat JAR package to the Blob Storage Folder
+on:
+  push:
+    # This pipeline will get triggered everytime there is a new tag created.
+    # It is required
+    tags: ["*"]
+
+jobs:
+  publish-fat-jar:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+    # Setting up JDK 8, this is required to build Feathr
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: "8"
+          distribution: "temurin"
+          server-id: ossrh
+          server-username: ORG_GRADLE_PROJECT_mavenCentralUsername
+          server-password: ORG_GRADLE_PROJECT_mavenCentralPassword
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: ORG_GRADLE_PROJECT_signingInMemoryKeyPassword
+
+    # Publish Released Fat Jar to Blob Storage 
+      - name: Gradle build
+        run: |  
+          ./gradlew build
+          # remote folder for CI upload
+          echo "CI_SPARK_REMOTE_JAR_FOLDER=feathr_jar_release" >> $GITHUB_ENV
+          # get local jar name without path
+          echo "FEATHR_LOCAL_JAR_FULL_NAME_PATH=$(ls build/libs/*.jar)" >> $GITHUB_ENV
+      
+      - name: Azure Blob Storage Upload (Overwrite)
+        uses: fixpoint/azblob-upload-artifact@v4
+        with:
+          connection-string: ${{secrets.SPARK_JAR_BLOB_CONNECTION_STRING}}
+          name: ${{ env.CI_SPARK_REMOTE_JAR_FOLDER}}
+          path: ${{ env.FEATHR_LOCAL_JAR_FULL_NAME_PATH}}
+          container: ${{secrets.SPARK_JAR_BLOB_CONTAINER}}
+          cleanup: "true"

--- a/.github/workflows/publish-fat-jar.yml
+++ b/.github/workflows/publish-fat-jar.yml
@@ -19,11 +19,6 @@ jobs:
         with:
           java-version: "8"
           distribution: "temurin"
-          server-id: ossrh
-          server-username: ORG_GRADLE_PROJECT_mavenCentralUsername
-          server-password: ORG_GRADLE_PROJECT_mavenCentralPassword
-          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          gpg-passphrase: ORG_GRADLE_PROJECT_signingInMemoryKeyPassword
 
     # Publish Released Fat Jar to Blob Storage 
       - name: Gradle build

--- a/.github/workflows/publish-to-maven.yml
+++ b/.github/workflows/publish-to-maven.yml
@@ -4,6 +4,8 @@ on:
     # This pipeline will get triggered everytime there is a new tag created.
     # It is required
     tags: ["*"]
+    branches:
+      - "gradlefix"
 
 jobs:
   publish-to-maven:
@@ -24,19 +26,6 @@ jobs:
           server-password: ORG_GRADLE_PROJECT_mavenCentralPassword
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: ORG_GRADLE_PROJECT_signingInMemoryKeyPassword
-
-    # CI release command defaults to publishSigned
-    # Sonatype release command defaults to sonaTypeBundleRelease
-    # Changing env names as documented here - https://vanniktech.github.io/gradle-maven-publish-plugin/central/#secrets
-      - name: Gradle Build and Publish to Maven central
-        run: |
-          ./gradlew publish
-          ./gradlew closeAndReleaseRepository
-        env:
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
 
     # Publish Released Fat Jar to Blob Storage 
       - name: Gradle build

--- a/.github/workflows/publish-to-maven.yml
+++ b/.github/workflows/publish-to-maven.yml
@@ -4,8 +4,6 @@ on:
     # This pipeline will get triggered everytime there is a new tag created.
     # It is required
     tags: ["*"]
-    branches:
-      - "gradlefix"
 
 jobs:
   publish-to-maven:
@@ -27,20 +25,15 @@ jobs:
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: ORG_GRADLE_PROJECT_signingInMemoryKeyPassword
 
-    # Publish Released Fat Jar to Blob Storage 
-      - name: Gradle build
-        run: |  
-          ./gradlew build
-          # remote folder for CI upload
-          echo "CI_SPARK_REMOTE_JAR_FOLDER=feathr_jar_release" >> $GITHUB_ENV
-          # get local jar name without path
-          echo "FEATHR_LOCAL_JAR_FULL_NAME_PATH=$(ls build/libs/*.jar)" >> $GITHUB_ENV
-      
-      - name: Azure Blob Storage Upload (Overwrite)
-        uses: fixpoint/azblob-upload-artifact@v4
-        with:
-          connection-string: ${{secrets.SPARK_JAR_BLOB_CONNECTION_STRING}}
-          name: ${{ env.CI_SPARK_REMOTE_JAR_FOLDER}}
-          path: ${{ env.FEATHR_LOCAL_JAR_FULL_NAME_PATH}}
-          container: ${{secrets.SPARK_JAR_BLOB_CONTAINER}}
-          cleanup: "true"
+    # CI release command defaults to publishSigned
+    # Sonatype release command defaults to sonaTypeBundleRelease
+    # Changing env names as documented here - https://vanniktech.github.io/gradle-maven-publish-plugin/central/#secrets
+      - name: Gradle Build and Publish to Maven central
+        run: |
+          ./gradlew publish
+          ./gradlew closeAndReleaseRepository
+        env:
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}


### PR DESCRIPTION
## Description
<!--
Hey! Thank you for the contribution! Please go through https://github.com/feathr-ai/feathr/blob/main/docs/dev_guide/pull_request_guideline.md for more information.

Describe what changes to make and why you are making these changes.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Previous publish to maven failure was fixed, however the follow up gradle build step failed. 
This PR decouple the "publish-to-maven" & "publish-fat-jar" into 2 workflow to make sure files created by gradle publish will not affect fat jar. 

## How was this PR tested?
<!--
Describe what testings you have done. If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

Tested in forked repo: https://github.com/Yuqing-cat/feathr/actions/runs/3949075762/jobs/6759841533

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide UI screenshot, the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.