### PR TITLE
Fix Hadoop S3 Key settings

### DIFF
--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/config/datasource/S3ResourceInfoSetter.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/config/datasource/S3ResourceInfoSetter.scala
@@ -12,10 +12,14 @@ private[feathr] class S3ResourceInfoSetter extends ResourceInfoSetter() {
   override def setupHadoopConfig(ss: SparkSession, context: Option[DataSourceConfig], resource: Option[Resource]): Unit = {
     ss.sparkContext
       .hadoopConfiguration.set("fs.s3a.endpoint", getAuthStr(S3_ENDPOINT, context, resource))
-    ss.sparkContext
-      .hadoopConfiguration.set("fs.s3a.access.key", getAuthStr(S3_ACCESS_KEY, context, resource))
-    ss.sparkContext
-      .hadoopConfiguration.set("fs.s3a.secret.key", getAuthStr(S3_SECRET_KEY, context, resource))
+    if (!getAuthStr(S3_ACCESS_KEY, context, resource).contains("None")) {
+      ss.sparkContext
+        .hadoopConfiguration.set("fs.s3a.access.key", getAuthStr(S3_ACCESS_KEY, context, resource))
+    }
+    if (!getAuthStr(S3_SECRET_KEY, context, resource).contains("None")) {
+      ss.sparkContext
+        .hadoopConfiguration.set("fs.s3a.secret.key", getAuthStr(S3_SECRET_KEY, context, resource))
+    }
   }
 
   def getAuthFromConfig(str: String, resource: Resource): String = {


### PR DESCRIPTION
## Description
<!--
Hey! Thank you for the contribution! Please go through https://github.com/feathr-ai/feathr/blob/main/docs/dev_guide/pull_request_guideline.md for more information.
-->

Resolves #XXX

## How was this PR tested?

Currently, if S3 keys are not provided, they are automatically set as "None" in the hadoop configurations. This prevents S3 IAM role from being used instead of the keys. This change ensures that the Hadoop configuration for the S3 keys is only set when the keys are provided. Otherwise, ignored. 

@xiaoyongzhu this PR is regarding the change we discussed

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide UI screenshot, the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.