### PR TITLE
Adding documentation for azure.cosmos.spark package and managing spark libraries

### DIFF
--- a/docs/how-to-guides/manage-library-spark-platform.md
+++ b/docs/how-to-guides/manage-library-spark-platform.md
@@ -13,4 +13,6 @@ If you want to intall maven, PyPi or private packages on your Synapse cluster, y
 
 ## Manage libraries for Azure Databricks
 
-Similarly to install an external library from PyPi, Maven or private packages, you can follow the official [databricks documentation](https://learn.microsoft.com/en-us/azure/databricks/libraries/cluster-libraries)
+Similarly to install an external library from PyPi, Maven or private packages on databricks you can follow the official [databricks documentation](https://learn.microsoft.com/en-us/azure/databricks/libraries/cluster-libraries)
+
+Note: There is currently a known issue with using azure.cosmos.spark package on databricks. Somehow this dependency is not resolving correctly on databricks when packaged through gradle and results in ClassNotFound error. To mitigate this issue, please install the azure.cosmos.spark package directly from [maven central](https://mvnrepository.com/artifact/com.azure.cosmos.spark/azure-cosmos-spark_3-1_2-12) following the above steps.

--- a/docs/how-to-guides/manage-library-spark-platform.md
+++ b/docs/how-to-guides/manage-library-spark-platform.md
@@ -1,0 +1,16 @@
+---
+layout: default
+title: Manage library for Azure Spark Compute (Azure Databricks and Azure Synapse)
+parent: How-to Guides
+---
+
+# Manage libraries for Azure Synapse
+
+Sometimes you might run into dependency issues where a particular dependency might be missing on your spark compute, most likely you will face this issue while executing sample notebooks in that environment.
+
+If you want to intall maven, PyPi or private packages on your Synapse cluster, you can follow the [official documentation](https://learn.microsoft.com/en-us/azure/synapse-analytics/spark/apache-spark-azure-portal-add-libraries) of how to do it for workspace, pool and session and the difference between each one of them.
+
+
+## Manage libraries for Azure Databricks
+
+Similarly to install an external library from PyPi, Maven or private packages, you can follow the official [databricks documentation](https://learn.microsoft.com/en-us/azure/databricks/libraries/cluster-libraries)

--- a/docs/how-to-guides/manage-library-spark-platform.md
+++ b/docs/how-to-guides/manage-library-spark-platform.md
@@ -14,5 +14,3 @@ If you want to intall maven, PyPi or private packages on your Synapse cluster, y
 ## Manage libraries for Azure Databricks
 
 Similarly to install an external library from PyPi, Maven or private packages on databricks you can follow the official [databricks documentation](https://learn.microsoft.com/en-us/azure/databricks/libraries/cluster-libraries)
-
-Note: There is currently a known issue with using azure.cosmos.spark package on databricks. Somehow this dependency is not resolving correctly on databricks when packaged through gradle and results in ClassNotFound error. To mitigate this issue, please install the azure.cosmos.spark package directly from [maven central](https://mvnrepository.com/artifact/com.azure.cosmos.spark/azure-cosmos-spark_3-1_2-12) following the above steps.

--- a/feathr_project/feathr/spark_provider/_databricks_submission.py
+++ b/feathr_project/feathr/spark_provider/_databricks_submission.py
@@ -231,7 +231,7 @@ class _FeathrDatabricksJobLauncher(SparkJobLauncher):
                 "coordinates": get_maven_artifact_fullname()}
             # Add json-schema dependency
             # TODO: find a proper way deal with unresolved dependencies
-            submission_params['libraries'][1]['maven']= {
+            submission_params["libraries"][1]["maven"]= {
                 "coordinates": "com.github.everit-org.json-schema:org.everit.json.schema:1.9.1",
                 "repo":"https://repository.mulesoft.org/nexus/content/repositories/public/"
                 }

--- a/feathr_project/feathr/spark_provider/_databricks_submission.py
+++ b/feathr_project/feathr/spark_provider/_databricks_submission.py
@@ -231,7 +231,10 @@ class _FeathrDatabricksJobLauncher(SparkJobLauncher):
                 "coordinates": get_maven_artifact_fullname()}
             # Add json-schema dependency
             # TODO: find a proper way deal with unresolved dependencies
-            # submission_params['libraries'][1]['maven']= {"coordinates": "com.github.everit-org.json-schema:org.everit.json.schema:1.9.1","repo":"https://repository.mulesoft.org/nexus/content/repositories/public/"}
+            submission_params['libraries'][1]['maven']= {
+                "coordinates": "com.github.everit-org.json-schema:org.everit.json.schema:1.9.1",
+                "repo":"https://repository.mulesoft.org/nexus/content/repositories/public/"
+                }
         else:
             submission_params["libraries"][0]["jar"] = self.upload_or_get_cloud_path(
                 main_jar_path)

--- a/feathr_project/feathr/spark_provider/_databricks_submission.py
+++ b/feathr_project/feathr/spark_provider/_databricks_submission.py
@@ -231,7 +231,7 @@ class _FeathrDatabricksJobLauncher(SparkJobLauncher):
                 "coordinates": get_maven_artifact_fullname()}
             # Add json-schema dependency
             # TODO: find a proper way deal with unresolved dependencies
-            submission_params['libraries'][1]['maven']= {"coordinates": "com.github.everit-org.json-schema:org.everit.json.schema:1.9.1","repo":"https://repository.mulesoft.org/nexus/content/repositories/public/"}
+            # submission_params['libraries'][1]['maven']= {"coordinates": "com.github.everit-org.json-schema:org.everit.json.schema:1.9.1","repo":"https://repository.mulesoft.org/nexus/content/repositories/public/"}
         else:
             submission_params["libraries"][0]["jar"] = self.upload_or_get_cloud_path(
                 main_jar_path)

--- a/feathr_project/feathr/spark_provider/_databricks_submission.py
+++ b/feathr_project/feathr/spark_provider/_databricks_submission.py
@@ -231,7 +231,7 @@ class _FeathrDatabricksJobLauncher(SparkJobLauncher):
                 "coordinates": get_maven_artifact_fullname()}
             # Add json-schema dependency
             # TODO: find a proper way deal with unresolved dependencies
-            submission_params["libraries"][1]["maven"]= {"coordinates": "com.github.everit-org.json-schema:org.everit.json.schema:1.9.1","repo":"https://repository.mulesoft.org/nexus/content/repositories/public/"}
+            submission_params['libraries'][1]['maven']= {"coordinates": "com.github.everit-org.json-schema:org.everit.json.schema:1.9.1","repo":"https://repository.mulesoft.org/nexus/content/repositories/public/"}
         else:
             submission_params["libraries"][0]["jar"] = self.upload_or_get_cloud_path(
                 main_jar_path)

--- a/feathr_project/feathr/spark_provider/_databricks_submission.py
+++ b/feathr_project/feathr/spark_provider/_databricks_submission.py
@@ -231,10 +231,7 @@ class _FeathrDatabricksJobLauncher(SparkJobLauncher):
                 "coordinates": get_maven_artifact_fullname()}
             # Add json-schema dependency
             # TODO: find a proper way deal with unresolved dependencies
-            submission_params["libraries"][1]["maven"]= {
-                "coordinates": "com.github.everit-org.json-schema:org.everit.json.schema:1.9.1",
-                "repo":"https://repository.mulesoft.org/nexus/content/repositories/public/"
-                }
+            submission_params["libraries"][1]["maven"]= {"coordinates": "com.github.everit-org.json-schema:org.everit.json.schema:1.9.1","repo":"https://repository.mulesoft.org/nexus/content/repositories/public/"}
         else:
             submission_params["libraries"][0]["jar"] = self.upload_or_get_cloud_path(
                 main_jar_path)


### PR DESCRIPTION
## Description
Adding documentation describing how to manage libraries from Maven, PyPi etc. on Spark Platforms in Azure i.e. Databricks and Synapse.
Also adding a note about azure.cosmos.spark package as that is not working despite being part of the gradle depedency and need to be installed explicitly on databricks. This will be needed by someone wanting to use CosmosDB as online store.

Resolves #1006 

## How was this PR tested?
Installed the library manually on Databricks cluster and it worked. 

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.