### PR TITLE
Support external/alien MVEL UDF

### DIFF
--- a/feathr-impl/src/main/java/com/linkedin/feathr/common/util/MvelContextUDFs.java
+++ b/feathr-impl/src/main/java/com/linkedin/feathr/common/util/MvelContextUDFs.java
@@ -37,9 +37,9 @@ public class MvelContextUDFs {
   private MvelContextUDFs() { }
 
   // register all the udfs defined in this class to the specific parser config
-  public static void registerUDFs(ParserConfiguration parserConfig) {
+  public static void registerUDFs(Class<?> clazz, ParserConfiguration parserConfig) {
     // Scans the class (MvelContextUDFs) for any methods annotated with ExportToMvel
-    for (Method method : MvelContextUDFs.class.getMethods()) {
+    for (Method method : clazz.getMethods()) {
       if (method.isAnnotationPresent(ExportToMvel.class)) {
         if (!Modifier.isStatic(method.getModifiers())) {
           throw new Error("MVEL context set up incorrectly. Imported method " + method + " must be static but is not.");
@@ -53,7 +53,7 @@ public class MvelContextUDFs {
   // parser context. Basically this is a way of adding UDFs.
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.METHOD)
-  private @interface ExportToMvel { }
+  public @interface ExportToMvel { }
 
   /**
    * Get the class type of the input object

--- a/feathr-impl/src/test/java/com/linkedin/feathr/common/AlienMvelContextUDFs.java
+++ b/feathr-impl/src/test/java/com/linkedin/feathr/common/AlienMvelContextUDFs.java
@@ -1,0 +1,37 @@
+package com.linkedin.feathr.common;
+
+import com.linkedin.feathr.common.util.MvelContextUDFs;
+
+/**
+ *
+ * MVEL is an open-source expression language and runtime that makes it easy to write concise statements that operate
+ * on structured data objects (such as Avro records), among other things.
+ *
+ * This class contains all the udfs used in Mvel for both online and offline
+ */
+public class AlienMvelContextUDFs {
+  // The udf naming in this class should use a_b_c form. (to be consistent with existing Spark built-in UDFs).
+  private AlienMvelContextUDFs() { }
+
+
+  /**
+   * convert input to upper case string
+   * @param input input string
+   * @return upper case input
+   */
+  @MvelContextUDFs.ExportToMvel
+  public static String toUpperCaseExt(String input) {
+    return input.toUpperCase();
+  }
+  /**
+   * convert input to upper case string
+   * @param input input string
+   * @return upper case input
+   */
+  @MvelContextUDFs.ExportToMvel
+  public static String toUpperCase(String input) {
+    return input.toUpperCase();
+  }
+
+}
+

--- a/feathr-impl/src/test/java/com/linkedin/feathr/common/util/MvelUDFExpressionTests.java
+++ b/feathr-impl/src/test/java/com/linkedin/feathr/common/util/MvelUDFExpressionTests.java
@@ -1,9 +1,10 @@
 package com.linkedin.feathr.common.util;
 
 import java.io.Serializable;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
+
+import com.linkedin.feathr.common.AlienMvelContextUDFs;
 import org.mvel2.MVEL;
 import org.mvel2.ParserConfiguration;
 import org.mvel2.ParserContext;
@@ -23,10 +24,18 @@ public class MvelUDFExpressionTests {
 
   @BeforeClass
   public void setup() {
-    MvelContextUDFs.registerUDFs(PARSER_CONFIG);
+    MvelContextUDFs.registerUDFs(MvelContextUDFs.class, PARSER_CONFIG);
+    MvelContextUDFs.registerUDFs(AlienMvelContextUDFs.class, PARSER_CONFIG);
     parserContext = new ParserContext(PARSER_CONFIG);
   }
 
+  @Test
+  public void testToUpperCaseExt() {
+    String getTopTerm = "toUpperCaseExt('hello')";
+    Serializable compiledExpression = MVEL.compileExpression(getTopTerm, parserContext);
+    String res = (String) (MVEL.executeExpression(compiledExpression, ""));
+    Assert.assertEquals(res, "HELLO");
+  }
 
   @Test
   public void testGetTopTerm() {

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/AnchoredFeaturesIntegTest.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/AnchoredFeaturesIntegTest.scala
@@ -294,7 +294,7 @@ class AnchoredFeaturesIntegTest extends FeathrIntegTest {
                              | anchors: {
                              |  anchor1: {
                              |    source: "anchorAndDerivations/nullValueSource.avro.json"
-                             |    key: "mId"
+                             |    key: "toUpperCaseExt(mId)"
                              |    features: {
                              |      featureWithNull: "isPresent(value) ? toNumeric(value) : 0"
                              |    }

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/TestFeathr.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/TestFeathr.scala
@@ -1,7 +1,7 @@
 package com.linkedin.feathr.offline
 
 import com.linkedin.feathr.common
-import com.linkedin.feathr.common.JoiningFeatureParams
+import com.linkedin.feathr.common.{AlienMvelContextUDFs, JoiningFeatureParams}
 import com.linkedin.feathr.offline.client.FeathrClient
 import com.linkedin.feathr.offline.config.{FeathrConfig, FeathrConfigLoader}
 import com.linkedin.feathr.offline.mvel.plugins.FeathrExpressionExecutionContext
@@ -31,7 +31,11 @@ abstract class TestFeathr {
   @BeforeClass
   def setup(): Unit = {
     setupSpark()
-    mvelContext.setupExecutorMvelContext(classOf[AlienFeatureValue], new AlienFeatureValueTypeAdaptor(), ss.sparkContext)
+    mvelContext.setupExecutorMvelContext(classOf[AlienFeatureValue],
+      new AlienFeatureValueTypeAdaptor(),
+      ss.sparkContext,
+      Some(classOf[AlienMvelContextUDFs].asInstanceOf[Class[Any]])
+    )
   }
 
   /**

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.10.4-rc1
+version=0.10.4-rc2
 SONATYPE_AUTOMATIC_RELEASE=true
 POM_ARTIFACT_ID=feathr_2.12


### PR DESCRIPTION
## Description
Add plugin to support external MVEL UDF
Instruction:
1. Use setupExecutorMvelContext(classOf[AlienFeatureValue],
      new AlienFeatureValueTypeAdaptor(),
      ss.sparkContext,
      Some(classOf[ExtMvelContextUDFs].asInstanceOf[Class[Any]]) to register external MVEL UDFS.
2. ExtMvelContextUDFs is a class with UDFs annotated by  @MvelContextUDFs.ExportToMvel
 
## How was this PR tested?
Added test case
 