### PR TITLE
Skip features optionally if feature data is missing

### DIFF
--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/swa/SlidingWindowAggregationJoiner.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/swa/SlidingWindowAggregationJoiner.scala
@@ -200,18 +200,18 @@ private[offline] class SlidingWindowAggregationJoiner(
         if (ss.sparkContext.isLocal && log.isDebugEnabled) {
           log.debug(
             s"*********Sliding window aggregation feature join stage with key: ${stringKeyTags} for feature " +
-              s"${featureNames.mkString(",")}*********")
+              s"${joinedFeatures.mkString(",")}*********")
           log.debug(
             s"First 3 rows in observation dataset :\n " +
               s"${labelDataDef.dataSource.collect().take(3).map(_.toString()).mkString("\n ")}")
         }
-        val windowAggAnchorsThisStage = featureNames.map(allWindowAggFeatures)
+        val windowAggAnchorsThisStage = joinedFeatures.map(allWindowAggFeatures)
         val windowAggAnchorDFThisStage = updatedWindowAggAnchorDFMap.filterKeys(windowAggAnchorsThisStage.toSet)
 
         val factDataDefs =
-          SlidingWindowFeatureUtils.getSWAAnchorGroups(updatedWindowAggAnchorDFMap).map {
+          SlidingWindowFeatureUtils.getSWAAnchorGroups(windowAggAnchorDFThisStage).map {
             anchorWithSourceToDFMap =>
-              val selectedFeatures = anchorWithSourceToDFMap.keySet.flatMap(_.selectedFeatures).filter(featureNames.contains(_))
+              val selectedFeatures = anchorWithSourceToDFMap.keySet.flatMap(_.selectedFeatures).filter(joinedFeatures.contains(_))
               val factData = anchorWithSourceToDFMap.head._2
               val anchor = anchorWithSourceToDFMap.head._1
               val filteredFactData = bloomFilter match {

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/swa/SlidingWindowAggregationJoiner.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/swa/SlidingWindowAggregationJoiner.scala
@@ -180,6 +180,7 @@ private[offline] class SlidingWindowAggregationJoiner(
         // Remove the features that are going to be skipped.
         val joinedFeatures = featureNames.diff(notJoinedFeatures.toSeq)
         if (joinedFeatures.nonEmpty) {
+          log.warn(s"----SKIPPED ADDING FEATURES : ${notJoinedFeatures} ------")
         val stringKeyTags = keyTags.map(keyTagList).map(k => s"CAST (${k} AS string)") // restore keyTag to column names in join config
 
         // get the bloom filter for the key combinations in this stage

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/transformation/AnchorToDataSourceMapper.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/transformation/AnchorToDataSourceMapper.scala
@@ -123,7 +123,7 @@ private[offline] class AnchorToDataSourceMapper(dataPathHandlers: List[DataPathH
           dataPathHandlers = dataPathHandlers)
       timeSeriesSource.get()
     }
-    catch {
+    catch {// todo - Add this functionality to only specific exception types and not for all error types.
       case e: Exception => if (shouldSkipFeature) ss.emptyDataFrame else throw e
     }
   }

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/transformation/AnchorToDataSourceMapper.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/transformation/AnchorToDataSourceMapper.scala
@@ -12,7 +12,7 @@ import com.linkedin.feathr.offline.source.accessor.DataPathHandler
 import com.linkedin.feathr.offline.source.dataloader.DataLoaderHandler
 import com.linkedin.feathr.offline.source.pathutil.{PathChecker, TimeBasedHdfsPathAnalyzer}
 import com.linkedin.feathr.offline.swa.SlidingWindowFeatureUtils
-import com.linkedin.feathr.offline.util.SourceUtils
+import com.linkedin.feathr.offline.util.{FeathrUtils, SourceUtils}
 import com.linkedin.feathr.offline.util.datetime.{DateTimeInterval, OfflineDateTimeUtils}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
@@ -63,12 +63,12 @@ private[offline] class AnchorToDataSourceMapper(dataPathHandlers: List[DataPathH
             }
         }
         val timeSeriesSource = DataSourceAccessor(ss = ss,
-                                                  source = source, 
-                                                  dateIntervalOpt = dateInterval, 
-                                                  expectDatumType = Some(expectDatumType), 
+                                                  source = source,
+                                                  dateIntervalOpt = dateInterval,
+                                                  expectDatumType = Some(expectDatumType),
                                                   failOnMissingPartition = failOnMissingPartition,
                                                   dataPathHandlers = dataPathHandlers)
-        
+
         anchorsWithDate.map(anchor => (anchor, timeSeriesSource))
     })
   }
@@ -100,8 +100,7 @@ private[offline] class AnchorToDataSourceMapper(dataPathHandlers: List[DataPathH
       val pathChecker = PathChecker(ss, dataLoaderHandlers)
       val pathAnalyzer = new TimeBasedHdfsPathAnalyzer(pathChecker, dataLoaderHandlers)
       val pathInfo = pathAnalyzer.analyze(factDataSource.path)
-      if (pathInfo.dateTimeResolution == DateTimeResolution.DAILY)
-      {
+      if (pathInfo.dateTimeResolution == DateTimeResolution.DAILY) {
         obsTimeRange.adjustWithDateTimeResolution(DateTimeResolution.DAILY)
       } else obsTimeRange
     } else {
@@ -110,16 +109,23 @@ private[offline] class AnchorToDataSourceMapper(dataPathHandlers: List[DataPathH
 
     val timeInterval = OfflineDateTimeUtils.getFactDataTimeRange(adjustedObsTimeRange, window, timeDelays)
     val needCreateTimestampColumn = SlidingWindowFeatureUtils.needCreateTimestampColumnFromPartition(factDataSource)
-    val timeSeriesSource =
-      DataSourceAccessor(
-        ss = ss,
-        source = factDataSource,
-        dateIntervalOpt = Some(timeInterval),
-        expectDatumType = None,
-        failOnMissingPartition = failOnMissingPartition,
-        addTimestampColumn = needCreateTimestampColumn,
-        dataPathHandlers = dataPathHandlers)
-    timeSeriesSource.get()
+    val shouldSkipFeature = FeathrUtils.getFeathrJobParam(ss.sparkContext.getConf, FeathrUtils.SKIP_MISSING_FEATURE).toBoolean
+
+    try {
+      val timeSeriesSource =
+        DataSourceAccessor(
+          ss = ss,
+          source = factDataSource,
+          dateIntervalOpt = Some(timeInterval),
+          expectDatumType = None,
+          failOnMissingPartition = failOnMissingPartition,
+          addTimestampColumn = needCreateTimestampColumn,
+          dataPathHandlers = dataPathHandlers)
+      timeSeriesSource.get()
+    }
+    catch {
+      case e: Exception => if (shouldSkipFeature) ss.emptyDataFrame else throw e
+    }
   }
 
   /**
@@ -171,7 +177,7 @@ private[offline] class AnchorToDataSourceMapper(dataPathHandlers: List[DataPathH
           addTimestampColumn = needCreateTimestampColumn,
           isStreaming = isStreaming,
           dataPathHandlers = dataPathHandlers)
-          
+
         anchors.map(anchor => (anchor, timeSeriesSource))
     })
   }

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/util/FeathrUtils.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/util/FeathrUtils.scala
@@ -27,6 +27,7 @@ private[offline] object FeathrUtils {
    */
   val SEQ_JOIN_ARRAY_EXPLODE_ENABLED = "seq.join.array.explode.enabled"
   val ENABLE_SALTED_JOIN = "enable.salted.join"
+  val SKIP_MISSING_FEATURE = "skip.missing.feature"
   val SALTED_JOIN_FREQ_ITEM_THRESHOLD = "salted.join.freq.item.threshold"
   val SALTED_JOIN_FREQ_ITEM_ESTIMATOR = "salted.join.freq.item.estimator"
   val SALTED_JOIN_PERSIST = "salted.join.persist"
@@ -45,9 +46,10 @@ private[offline] object FeathrUtils {
     CHECKPOINT_OUTPUT_PATH -> "/tmp/feathr/checkpoints",
     ENABLE_CHECKPOINT -> "false",
     DEBUG_OUTPUT_PART_NUM -> "200",
-    FAIL_ON_MISSING_PARTITION -> "false",
+    FAIL_ON_MISSING_PARTITION -> "true",
     SEQ_JOIN_ARRAY_EXPLODE_ENABLED -> "true",
     ENABLE_SALTED_JOIN -> "false",
+    SKIP_MISSING_FEATURE -> "true",
     // If one key appears more than 0.02% in the dataset, we will salt this join key and split them into multiple partitions
     // This is an empirical value
     SALTED_JOIN_FREQ_ITEM_THRESHOLD -> "0.0002",

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/util/FeathrUtils.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/util/FeathrUtils.scala
@@ -49,7 +49,7 @@ private[offline] object FeathrUtils {
     FAIL_ON_MISSING_PARTITION -> "false",
     SEQ_JOIN_ARRAY_EXPLODE_ENABLED -> "true",
     ENABLE_SALTED_JOIN -> "false",
-    SKIP_MISSING_FEATURE -> "true",
+    SKIP_MISSING_FEATURE -> "false",
     // If one key appears more than 0.02% in the dataset, we will salt this join key and split them into multiple partitions
     // This is an empirical value
     SALTED_JOIN_FREQ_ITEM_THRESHOLD -> "0.0002",

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/util/FeathrUtils.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/util/FeathrUtils.scala
@@ -46,7 +46,7 @@ private[offline] object FeathrUtils {
     CHECKPOINT_OUTPUT_PATH -> "/tmp/feathr/checkpoints",
     ENABLE_CHECKPOINT -> "false",
     DEBUG_OUTPUT_PART_NUM -> "200",
-    FAIL_ON_MISSING_PARTITION -> "true",
+    FAIL_ON_MISSING_PARTITION -> "false",
     SEQ_JOIN_ARRAY_EXPLODE_ENABLED -> "true",
     ENABLE_SALTED_JOIN -> "false",
     SKIP_MISSING_FEATURE -> "true",

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/SlidingWindowAggIntegTest.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/SlidingWindowAggIntegTest.scala
@@ -349,6 +349,14 @@ class SlidingWindowAggIntegTest extends FeathrIntegTest {
       """
         |sources: {
         |  swaSource: {
+        |    location: { path: "slidingWindowAgg/localSWADefaultTest/daily" }
+        |    timePartitionPattern: "yyyy/MM/dd"
+        |    timeWindowParameters: {
+        |      timestampColumn: "timestamp"
+        |      timestampColumnFormat: "yyyy-MM-dd"
+        |    }
+        |  }
+        |  missingSource: {
         |    location: { path: "slidingWindowAgg/missingFeatureData/daily" }
         |    timePartitionPattern: "yyyy/MM/dd"
         |    timeWindowParameters: {
@@ -369,12 +377,18 @@ class SlidingWindowAggIntegTest extends FeathrIntegTest {
         |        window: 3d
         |        default: 10
         |      }
-        |      simpleFeature: {
+        |    }
+        |  }
+        |  missingAnchor: {
+        |  source: "missingSource"
+        |  key: "x"
+        |  features: {
+        |   simpleFeature: {
         |        def: "aggregationWindow"
         |        aggregation: COUNT
         |        window: 3d
         |        default: 20
-        |      }
+        |     }
         |    }
         |  }
         |}
@@ -383,7 +397,7 @@ class SlidingWindowAggIntegTest extends FeathrIntegTest {
     res.show()
     val df = res.collect()(0)
     assertEquals(df.getAs[Float]("simplePageViewCount"), 10f)
-    assertEquals(df.getAs[Float]("simpleFeature"), 20f)
+    assert(!res.columns.contains("simpleFeature"))
   }
 
   /**

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/SlidingWindowAggIntegTest.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/SlidingWindowAggIntegTest.scala
@@ -1086,7 +1086,6 @@ class SlidingWindowAggIntegTest extends FeathrIntegTest {
   }
 
 
-  /**
   @Test
   def testSWACountDistinct(): Unit = {
     val featureDefAsString =
@@ -1166,5 +1165,5 @@ class SlidingWindowAggIntegTest extends FeathrIntegTest {
     val dfs = runLocalFeatureJoinForTest(featureJoinAsString, featureDefAsString, "featuresWithFilterObs.avro.json").data
 
     validateRows(dfs.select(keyField, features: _*).collect().sortBy(row => row.getAs[Int](keyField)), expectedRows)
-  }*/
+  }
 }

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/SlidingWindowAggIntegTest.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/SlidingWindowAggIntegTest.scala
@@ -316,9 +316,10 @@ class SlidingWindowAggIntegTest extends FeathrIntegTest {
   }
 
   /**
-   * SWA test with default values
+   * SWA test with missing features. To enable this test, set the value of FeatureUtils.SKIP_MISSING_FEATURE to True. From
+   * Spark 3.1, SparkContext.updateConf() is not supported.
    */
-  @Test
+  @Test(enabled = false)
   def testSWAWithMissingFeatureData(): Unit = {
     val joinConfigAsString =
       """

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.10.4-rc2
+version=0.10.4-rc3
 SONATYPE_AUTOMATIC_RELEASE=true
 POM_ARTIFACT_ID=feathr_2.12


### PR DESCRIPTION
-> Add a spark configuration to skip features and join the remaining features if unable to load feature data.
-> This is not the default option, and needs to be configured.
-> This PR addresses for SWA features only, a later PR will extend it to other features as well.