### PR TITLE
Revert "Add retry when data loading fails (#930)"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ project.ext.spec = [
         ],
         'scala' : [
             'scala_library' : "org.scala-lang:scala-library:$ver.scala",
-            'scalatest' : "org.scalatest:scalatest_$ver.scala_rt:3.2.9",
+            'scalatest' : "org.scalatest:scalatest_$ver.scala_rt:3.0.0",
         ],
         'avro' : "org.apache.avro:avro:1.10.2",
         "avroUtil": "com.linkedin.avroutil1:helper-all:0.2.100",
@@ -153,7 +153,7 @@ project.ext.spec = [
         "antlr": "org.antlr:antlr4:4.8",
         "antlrRuntime": "org.antlr:antlr4-runtime:4.8",
         "jsqlparser": "com.github.jsqlparser:jsqlparser:3.1",
-        "scalaTestPlus": "org.scalatestplus:mockito-3-4_2.12:3.3.0.0-SNAP3",
+
     ]
 ]
 

--- a/feathr-impl/build.gradle
+++ b/feathr-impl/build.gradle
@@ -81,7 +81,6 @@ dependencies {
   testImplementation spec.product.scala.scalatest
   testImplementation spec.product.testing
   testImplementation spec.product.jdiagnostics
-  testImplementation spec.product.scalaTestPlus
 }
 
 // Since there are cross-calls from Scala to Java, we use joint compiler

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/source/dataloader/BatchDataLoader.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/source/dataloader/BatchDataLoader.scala
@@ -4,6 +4,8 @@ import com.linkedin.feathr.common.exception.{ErrorLabel, FeathrInputDataExceptio
 import com.linkedin.feathr.offline.config.location.DataLocation
 import com.linkedin.feathr.offline.generation.SparkIOUtils
 import com.linkedin.feathr.offline.job.DataSourceUtils.getSchemaFromAvroDataFile
+import com.linkedin.feathr.offline.source.dataloader.DataLoaderHandler
+import com.linkedin.feathr.offline.util.DelimiterUtils.checkDelimiterOption
 import org.apache.avro.Schema
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.mapred.JobConf
@@ -14,9 +16,7 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
  * @param ss the spark session
  * @param path input data path
  */
-private[offline] class BatchDataLoader(val ss: SparkSession,
-                                       val location: DataLocation,
-                                       val dataLoaderHandlers: List[DataLoaderHandler]) extends DataLoader {
+private[offline] class BatchDataLoader(ss: SparkSession, location: DataLocation, dataLoaderHandlers: List[DataLoaderHandler]) extends DataLoader {
 
   /**
    * get the schema of the source. It's only used in the deprecated DataSource.getDataSetAndSchema
@@ -48,22 +48,25 @@ private[offline] class BatchDataLoader(val ss: SparkSession,
    * @return an dataframe
    */
   override def loadDataFrame(): DataFrame = {
-     loadDataFrameWithRetry(Map(), new JobConf(ss.sparkContext.hadoopConfiguration), MAX_DATA_LOAD_RETRY)
+    loadDataFrame(Map(), new JobConf(ss.sparkContext.hadoopConfiguration))
   }
+
   /**
    * load the source data as dataframe.
    * @param dataIOParameters extra parameters
    * @param jobConf Hadoop JobConf to be passed
-   * @param retry number of times to retry when data loading fails
    * @return an dataframe
    */
-  def loadDataFrameWithRetry(dataIOParameters: Map[String, String], jobConf: JobConf, retry: Int): DataFrame = {
+  def loadDataFrame(dataIOParameters: Map[String, String], jobConf: JobConf): DataFrame = {
     val sparkConf = ss.sparkContext.getConf
     val inputSplitSize = sparkConf.get("spark.feathr.input.split.size", "")
     val dataIOParametersWithSplitSize = Map(SparkIOUtils.SPLIT_SIZE -> inputSplitSize) ++ dataIOParameters
     val dataPath = location.getPath
 
     log.info(s"Loading ${location} as DataFrame, using parameters ${dataIOParametersWithSplitSize}")
+
+    // Get csvDelimiterOption set with spark.feathr.inputFormat.csvOptions.sep and check if it is set properly (Only for CSV and TSV)
+    val csvDelimiterOption = checkDelimiterOption(ss.sqlContext.getConf("spark.feathr.inputFormat.csvOptions.sep", ","))
 
     try {
       import scala.util.control.Breaks._
@@ -84,20 +87,12 @@ private[offline] class BatchDataLoader(val ss: SparkSession,
       }
       df
     } catch {
-      case _: Throwable =>
-        // If data loading from source failed, retry it automatically, as it might due to data source still being written into.
-        log.info(s"Loading ${location} failed, retrying for ${retry}-th time..")
-        if (retry > 0) {
-          Thread.sleep(DATA_LOAD_WAIT_IN_MS)
-          loadDataFrameWithRetry(dataIOParameters, jobConf, retry - 1)
-        } else {
-          // Throwing exception to avoid dataLoaderHandler hook exception from being swallowed.
-          throw new FeathrInputDataException(ErrorLabel.FEATHR_USER_ERROR, s"Failed to load ${dataPath} after ${MAX_DATA_LOAD_RETRY} retries.")
-        }
+      case feathrException: FeathrInputDataException =>
+        println(feathrException.toString)
+        throw feathrException // Throwing exception to avoid dataLoaderHandler hook exception from being swallowed.
+      case e: Throwable => //TODO: Analyze all thrown exceptions, instead of swalling them all, and reading as a csv
+        println(e.toString)
+        ss.read.format("csv").option("header", "true").option("delimiter", csvDelimiterOption).load(dataPath)
     }
   }
-  // Retry 2 times if data source loading fails
-  val MAX_DATA_LOAD_RETRY = 2
-  // Wait for 10 minutes and retry if data source loading fails
-  val DATA_LOAD_WAIT_IN_MS = 10*60*1000
 }

--- a/feathr-impl/src/test/java/com/linkedin/feathr/common/AutoTensorizableTypesTest.java
+++ b/feathr-impl/src/test/java/com/linkedin/feathr/common/AutoTensorizableTypesTest.java
@@ -6,6 +6,7 @@ import com.linkedin.feathr.common.tensor.TensorType;
 import com.linkedin.feathr.common.types.PrimitiveType;
 import java.util.Optional;
 
+import org.scalatest.testng.TestNGSuite;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -13,7 +14,7 @@ import static java.util.Collections.*;
 import static org.testng.Assert.*;
 
 
-public class AutoTensorizableTypesTest {
+public class AutoTensorizableTypesTest extends TestNGSuite {
   private static final TensorType NTV_EQUIVALENT_TENSOR_TYPE = new TensorType(PrimitiveType.FLOAT, singletonList(
       PrimitiveDimensionType.STRING));
 

--- a/feathr-impl/src/test/java/com/linkedin/feathr/common/FeatureTypeConfigTest.java
+++ b/feathr-impl/src/test/java/com/linkedin/feathr/common/FeatureTypeConfigTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.feathr.common;
 
 import com.linkedin.feathr.common.tensor.TensorType;
+import org.scalatest.testng.TestNGSuite;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -10,7 +11,7 @@ import org.testng.annotations.Test;
  * Unit tests for {@link FeatureTypeConfig}
  *
  */
-public class FeatureTypeConfigTest {
+public class FeatureTypeConfigTest extends TestNGSuite {
 
   @DataProvider
   public Object[][] FeatureTypeConstructorWithAutoTZTestCases() {

--- a/feathr-impl/src/test/java/com/linkedin/feathr/common/TestFeatureDependencyGraph.java
+++ b/feathr-impl/src/test/java/com/linkedin/feathr/common/TestFeatureDependencyGraph.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.scalatest.testng.TestNGSuite;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -20,7 +21,7 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
 
-public class TestFeatureDependencyGraph {
+public class TestFeatureDependencyGraph extends TestNGSuite {
 
   /*
     Description of test scenario:

--- a/feathr-impl/src/test/java/com/linkedin/feathr/common/TestFeatureValue.java
+++ b/feathr-impl/src/test/java/com/linkedin/feathr/common/TestFeatureValue.java
@@ -19,6 +19,7 @@ import java.util.Set;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+import org.scalatest.testng.TestNGSuite;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -26,7 +27,7 @@ import org.testng.annotations.Test;
 import static java.util.Collections.*;
 
 
-public class TestFeatureValue {
+public class TestFeatureValue extends TestNGSuite {
 
   private static final float DEFAULT_VALUE = FeatureValue.DEFAULT_VALUE;
   private static final String EMPTY_TERM = FeatureValue.EMPTY_TERM;

--- a/feathr-impl/src/test/java/com/linkedin/feathr/common/types/TestFeatureTypes.java
+++ b/feathr-impl/src/test/java/com/linkedin/feathr/common/types/TestFeatureTypes.java
@@ -3,12 +3,13 @@ package com.linkedin.feathr.common.types;
 import java.util.Collections;
 
 import com.linkedin.feathr.common.tensor.TensorType;
+import org.scalatest.testng.TestNGSuite;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
 
 
-public class TestFeatureTypes {
+public class TestFeatureTypes extends TestNGSuite {
   @Test
   public void checkBasicTypes() {
     assertEquals(BooleanFeatureType.INSTANCE.getBasicType(), FeatureType.BasicType.BOOLEAN);

--- a/feathr-impl/src/test/java/com/linkedin/feathr/common/types/TestQuinceFeatureTypeMapper.java
+++ b/feathr-impl/src/test/java/com/linkedin/feathr/common/types/TestQuinceFeatureTypeMapper.java
@@ -6,6 +6,7 @@ import com.linkedin.feathr.common.tensor.PrimitiveDimensionType;
 import com.linkedin.feathr.common.tensor.TensorCategory;
 import com.linkedin.feathr.common.tensor.TensorType;
 import com.linkedin.feathr.common.value.QuinceFeatureTypeMapper;
+import org.scalatest.testng.TestNGSuite;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -13,7 +14,7 @@ import static java.util.Collections.*;
 import static org.testng.Assert.*;
 
 
-public class TestQuinceFeatureTypeMapper {
+public class TestQuinceFeatureTypeMapper extends TestNGSuite {
   @DataProvider
   public Object[][] quinceTypeMapperCases() {
     return new Object[][] {

--- a/feathr-impl/src/test/java/com/linkedin/feathr/common/util/MvelUDFExpressionTests.java
+++ b/feathr-impl/src/test/java/com/linkedin/feathr/common/util/MvelUDFExpressionTests.java
@@ -8,6 +8,7 @@ import com.linkedin.feathr.common.AlienMvelContextUDFs;
 import org.mvel2.MVEL;
 import org.mvel2.ParserConfiguration;
 import org.mvel2.ParserContext;
+import org.scalatest.testng.TestNGSuite;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -17,7 +18,7 @@ import org.testng.annotations.Test;
 /**
  * Unit tests for {@link MvelContextUDFs} using expressions
  */
-public class MvelUDFExpressionTests {
+public class MvelUDFExpressionTests extends TestNGSuite {
 
   private static final ParserConfiguration PARSER_CONFIG = new ParserConfiguration();
   private ParserContext parserContext;

--- a/feathr-impl/src/test/java/com/linkedin/feathr/common/util/TestMvelContextUDFs.java
+++ b/feathr-impl/src/test/java/com/linkedin/feathr/common/util/TestMvelContextUDFs.java
@@ -11,6 +11,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import org.scalatest.testng.TestNGSuite;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -22,7 +23,7 @@ import static org.testng.Assert.*;
 /**
  * Unit tests for {@link MvelContextUDFs}
  */
-public class TestMvelContextUDFs {
+public class TestMvelContextUDFs extends TestNGSuite {
   @Test
   public void testGetDataType() {
     Assert.assertEquals(get_data_type("A"), "java.lang.String");

--- a/feathr-impl/src/test/java/com/linkedin/feathr/common/value/TestFeatureValueOldAPICompatibility.java
+++ b/feathr-impl/src/test/java/com/linkedin/feathr/common/value/TestFeatureValueOldAPICompatibility.java
@@ -14,13 +14,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
+import org.scalatest.testng.TestNGSuite;
 import org.testng.annotations.Test;
 
 import static java.util.Collections.*;
 import static org.testng.Assert.*;
 
 
-public class TestFeatureValueOldAPICompatibility {
+public class TestFeatureValueOldAPICompatibility extends TestNGSuite {
   @Test
   public void basicEqualityChecks() {
     {

--- a/feathr-impl/src/test/java/com/linkedin/feathr/common/value/TestFeatureValues.java
+++ b/feathr-impl/src/test/java/com/linkedin/feathr/common/value/TestFeatureValues.java
@@ -15,6 +15,7 @@ import com.linkedin.feathr.common.types.*;
 import java.util.Arrays;
 import java.util.Map;
 
+import org.scalatest.testng.TestNGSuite;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -22,7 +23,7 @@ import static java.util.Collections.*;
 import static org.testng.Assert.*;
 
 
-public class TestFeatureValues {
+public class TestFeatureValues extends TestNGSuite {
   private static final Representable[] TENSOR_STRING_FLOAT_TYPE = new Representable[]{Primitive.STRING, Primitive.FLOAT};
   private static final Representable[] TENSOR_INT_FLOAT_TYPE = new Representable[]{Primitive.INT, Primitive.FLOAT};
 

--- a/feathr-impl/src/test/java/com/linkedin/feathr/offline/TestMvelContext.java
+++ b/feathr-impl/src/test/java/com/linkedin/feathr/offline/TestMvelContext.java
@@ -1,5 +1,6 @@
 package com.linkedin.feathr.offline;
 
+import org.scalatest.testng.TestNGSuite;
 import org.testng.annotations.Test;
 
 import java.util.HashMap;
@@ -9,7 +10,7 @@ import static com.linkedin.feathr.common.util.MvelContextUDFs.*;
 import static org.testng.Assert.assertEquals;
 
 
-public class TestMvelContext {
+public class TestMvelContext extends TestNGSuite {
   @Test
   public void testCosineSimilarity() {
     // Test basic cosine similarity calculation

--- a/feathr-impl/src/test/java/com/linkedin/feathr/offline/TestMvelExpression.java
+++ b/feathr-impl/src/test/java/com/linkedin/feathr/offline/TestMvelExpression.java
@@ -12,6 +12,7 @@ import org.mvel2.integration.PropertyHandlerFactory;
 import org.mvel2.integration.VariableResolverFactory;
 import org.mvel2.integration.impl.MapVariableResolverFactory;
 import org.mvel2.optimizers.OptimizerFactory;
+import org.scalatest.testng.TestNGSuite;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -21,7 +22,7 @@ import static org.testng.Assert.*;
 /**
  * Test MVEL expression evaluator
  */
-public class TestMvelExpression {
+public class TestMvelExpression extends TestNGSuite {
   @Test(description = "test mvel expression foo.bar on a map field of GenericRecord, where foo is the map field "
       + "and bar is the target key in the map")
   public void testMVELExpressionOnMap() {

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/FeathrIntegTest.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/FeathrIntegTest.scala
@@ -21,7 +21,7 @@ abstract class FeathrIntegTest extends TestFeathr {
 
   val generatedDataFolder = "src/integTest/generated"
   val mockDataFolder = generatedDataFolder + "/mockData"
-  val trainingData = "src/test/resources/obs/obs.csv"
+  val trainingData = "src/test/resources/obs/"
   val featureData = mockDataFolder + "/a_feature_data"
 
   /**

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/SlidingWindowAggIntegTest.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/SlidingWindowAggIntegTest.scala
@@ -1000,6 +1000,7 @@ class SlidingWindowAggIntegTest extends FeathrIntegTest {
   }
 
 
+  /**
   @Test
   def testSWACountDistinct(): Unit = {
     val featureDefAsString =
@@ -1079,5 +1080,5 @@ class SlidingWindowAggIntegTest extends FeathrIntegTest {
     val dfs = runLocalFeatureJoinForTest(featureJoinAsString, featureDefAsString, "featuresWithFilterObs.avro.json").data
 
     validateRows(dfs.select(keyField, features: _*).collect().sortBy(row => row.getAs[Int](keyField)), expectedRows)
-  }
+  }*/
 }

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/TestFeathr.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/TestFeathr.scala
@@ -10,13 +10,14 @@ import com.linkedin.feathr.offline.util.FeathrTestUtils
 import org.apache.avro.generic.GenericRecord
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.SparkSession
+import org.scalatest.testng.TestNGSuite
 import org.testng.annotations.{AfterClass, BeforeClass}
 
 import scala.collection.convert.wrapAll._
 import scala.reflect.ClassTag
 
 // abstract class for all feathr tests
-abstract class TestFeathr {
+abstract class TestFeathr extends TestNGSuite {
   protected var ss: SparkSession = _
   protected var conf: Configuration = _
   protected var feathr: FeathrClient = _

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/TestFeathrUtils.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/TestFeathrUtils.scala
@@ -1,11 +1,11 @@
 package com.linkedin.feathr.offline
 
 import com.linkedin.feathr.offline.util.FeathrUtils
-
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert._
 import org.testng.annotations.Test
 
-class TestFeathrUtils {
+class TestFeathrUtils extends TestNGSuite {
   private val TEST_FEATHR_VERSION = "1.2.3"
 
   /**

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/client/TestDataFrameColName.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/client/TestDataFrameColName.scala
@@ -6,7 +6,7 @@ import com.linkedin.feathr.offline.anchored.feature.{FeatureAnchor, FeatureAncho
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{DoubleType, StringType, StructField, StructType}
 import org.mockito.Mockito.when
-import org.scalatestplus.mockito.MockitoSugar.mock
+import org.scalatest.mockito.MockitoSugar.mock
 import org.testng.Assert.assertEquals
 import org.testng.annotations.Test
 

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/config/TestDataSourceLoader.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/config/TestDataSourceLoader.scala
@@ -7,12 +7,12 @@ import com.jasonclawson.jackson.dataformat.hocon.HoconFactory
 import com.linkedin.feathr.common.FeathrJacksonScalaModule
 import com.linkedin.feathr.offline.config.location.{Jdbc, LocationUtils, Snowflake}
 import com.linkedin.feathr.offline.source.{DataSource, SourceFormatType}
-import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.FunSuite
 
 import scala.collection.mutable
 
 
-class TestDataSourceLoader extends AnyFunSuite {
+class TestDataSourceLoader extends FunSuite {
   /// Base line test to ensure backward compatibility
   test("DataSourceLoader.deserialize BaseLine") {
     val configDoc =

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/config/TestFeatureGroupsGenerator.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/config/TestFeatureGroupsGenerator.scala
@@ -1,13 +1,13 @@
 package com.linkedin.feathr.offline.config
 
 import com.linkedin.feathr.common.exception.FeathrConfigException
-
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert
 import org.testng.annotations.Test
 
 import scala.io.Source
 
-class TestFeatureGroupsGenerator{
+class TestFeatureGroupsGenerator extends TestNGSuite{
 
   private val _feathrConfigLoader = FeathrConfigLoader()
 

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/config/TestFeatureJoinConfig.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/config/TestFeatureJoinConfig.scala
@@ -2,14 +2,14 @@ package com.linkedin.feathr.offline.config
 
 import com.linkedin.feathr.common.{DateParam, JoiningFeatureParams}
 import com.linkedin.feathr.offline.anchored.WindowTimeUnit
-
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert
 import org.testng.annotations.Test
 
 /**
  * Test suite to test parsing of join configs
  */
-class TestFeatureJoinConfig{
+class TestFeatureJoinConfig extends TestNGSuite{
 
   /**
    * Settings config with observationDataTimeSettings and joinTimeSettings.

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/config/location/TestDesLocation.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/config/location/TestDesLocation.scala
@@ -1,19 +1,21 @@
 package com.linkedin.feathr.offline.config.location
 
-import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
+import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.module.caseclass.mapper.CaseClassObjectMapper
 import com.jasonclawson.jackson.dataformat.hocon.HoconFactory
 import com.linkedin.feathr.common.FeathrJacksonScalaModule
 import com.linkedin.feathr.offline.config.DataSourceLoader
 import com.linkedin.feathr.offline.config.location.LocationUtils.envSubstitute
+import com.linkedin.feathr.offline.config.location.{DataLocation, Jdbc, SimplePath}
 import com.linkedin.feathr.offline.generation.SparkIOUtils
 import com.linkedin.feathr.offline.source.DataSource
-import org.apache.hadoop.mapred.JobConf
+import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.sql.SparkSession
-import org.scalatest.funsuite.AnyFunSuite
+import org.apache.hadoop.mapred.JobConf
+import org.scalatest.FunSuite
 
-class TestDesLocation extends AnyFunSuite {
+class TestDesLocation extends FunSuite {
   val jackson = (new ObjectMapper(new HoconFactory) with CaseClassObjectMapper)
     .registerModule(FeathrJacksonScalaModule) // DefaultScalaModule causes a fail on holdem
     .configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true)

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/derived/TestSequentialJoinAsDerivation.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/derived/TestSequentialJoinAsDerivation.scala
@@ -18,7 +18,7 @@ import org.apache.spark.sql.functions.{when => _, _}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{AnalysisException, DataFrame, Row, SparkSession}
 import org.mockito.Mockito._
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.testng.Assert._
 import org.testng.annotations.{DataProvider, Test}
 import org.apache.spark.sql.internal.SQLConf

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/generation/TestFeatureGenFeatureGrouper.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/generation/TestFeatureGenFeatureGrouper.scala
@@ -6,7 +6,7 @@ import com.linkedin.feathr.offline.{AssertFeatureUtils, FeatureDataFrame, JoinKe
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types._
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.testng.Assert._
 import org.testng.annotations.Test
 

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/generation/TestFeatureGenKeyTagAnalyzer.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/generation/TestFeatureGenKeyTagAnalyzer.scala
@@ -8,7 +8,7 @@ import com.linkedin.feathr.offline.derived.DerivedFeature
 import com.linkedin.feathr.offline.job.FeatureGenSpec
 import com.linkedin.feathr.offline.logical.FeatureGroups
 import org.mockito.Mockito._
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.testng.Assert._
 import org.testng.annotations.Test
 

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/generation/TestIncrementalAggSnapshotLoader.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/generation/TestIncrementalAggSnapshotLoader.scala
@@ -8,7 +8,7 @@ import com.typesafe.config.Config
 import org.apache.hadoop.fs.FileSystem
 import org.apache.spark.sql.DataFrame
 import org.mockito.Mockito.{verify, when}
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.testng.Assert.{assertEquals, assertTrue}
 import org.testng.annotations.Test
 

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/generation/TestPostGenPruner.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/generation/TestPostGenPruner.scala
@@ -8,7 +8,7 @@ import com.linkedin.feathr.offline.derived.DerivedFeature
 import com.linkedin.feathr.offline.job.FeatureGenSpec
 import com.linkedin.feathr.offline.logical.{FeatureGroups, MultiStageJoinPlan}
 import org.mockito.Mockito.when
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.testng.Assert.assertEquals
 import org.testng.annotations.Test
 

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/generation/TestPushToRedisOutputProcessor.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/generation/TestPushToRedisOutputProcessor.scala
@@ -7,7 +7,7 @@ import com.linkedin.feathr.offline.{AssertFeatureUtils, TestFeathr}
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.types.{ArrayType, BooleanType, FloatType, IntegerType, StringType, StructField, StructType}
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.testng.annotations.Test
 
 import java.util.Base64

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/generation/TestStageEvaluator.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/generation/TestStageEvaluator.scala
@@ -7,7 +7,7 @@ import com.linkedin.feathr.offline.evaluator.{BaseDataFrameMetadata, DerivedFeat
 import com.linkedin.feathr.offline.logical.{FeatureGroups, MultiStageJoinPlan}
 import com.linkedin.feathr.offline.{FeatureDataFrame, TestFeathr}
 import org.mockito.Mockito._
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.testng.Assert._
 import org.testng.annotations.Test
 

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/job/TestFeatureJoinJob.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/job/TestFeatureJoinJob.scala
@@ -7,13 +7,13 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.log4j.{Level, Logger}
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{Row, SparkSession}
-
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert._
 import org.testng.annotations.{AfterClass, BeforeClass, Test}
 
 import scala.collection.mutable
 
-class TestFeatureJoinJob{
+class TestFeatureJoinJob extends TestNGSuite{
   private val generatedDataFolder = "src/test/generated"
 
   var ss: SparkSession = _

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/job/TestFeatureJoinJobUtils.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/job/TestFeatureJoinJobUtils.scala
@@ -1,10 +1,10 @@
 package com.linkedin.feathr.offline.job
 
 import com.linkedin.feathr.offline.config.FeatureJoinConfig
-
+import org.scalatest.testng.TestNGSuite
 import org.testng.annotations.Test
 
-class TestJoinJobUtils{
+class TestJoinJobUtils extends TestNGSuite{
 
   @Test(
     expectedExceptions = Array(classOf[RuntimeException]),

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/job/TestFeatureTransformation.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/job/TestFeatureTransformation.scala
@@ -15,7 +15,7 @@ import com.linkedin.feathr.sparkcommon.{SimpleAnchorExtractorSpark, SourceKeyExt
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 import org.mockito.Mockito._
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.testng.Assert.assertEquals
 import org.testng.annotations.{DataProvider, Test}
 

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/job/featureGen/TestFeatureGenConfigOverrider.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/job/featureGen/TestFeatureGenConfigOverrider.scala
@@ -2,14 +2,14 @@ package com.linkedin.feathr.offline.job.featureGen
 
 import com.linkedin.feathr.offline.config.FeathrConfigLoader
 import com.linkedin.feathr.offline.job.{FeatureGenConfigOverrider, FeatureGenJobContext}
-
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.{assertEquals, assertTrue}
 import org.testng.annotations.Test
 
 /**
  * Test suite to test the [[FeatureGenConfigOverrider]] class
  */
-class TestFeatureGenConfigOverrider{
+class TestFeatureGenConfigOverrider extends TestNGSuite{
 
   private val feathrConfigLoader = FeathrConfigLoader()
   @Test(description = "test feature definition override parsing for feature-gen job")

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/job/featureGen/TestFeatureGenJobParser.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/job/featureGen/TestFeatureGenJobParser.scala
@@ -1,14 +1,14 @@
 package com.linkedin.feathr.offline.job.featureGen
 
 import com.linkedin.feathr.offline.job.FeatureGenJobContext
-
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.annotations.Test
 
 /**
  * Test the [[FeatureGenJobContext]] class' parser
  */
-class TestFeatureGenJobParser{
+class TestFeatureGenJobParser extends TestNGSuite{
 
   @Test(description = "test params-override parameter parsing for feature-gen job")
   def featureGenJobParamsTest(): Unit = {

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/job/featureGen/TestFeatureGenSpecParser.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/job/featureGen/TestFeatureGenSpecParser.scala
@@ -1,11 +1,11 @@
 package com.linkedin.feathr.offline.job.featureGen
 
 import com.linkedin.feathr.offline.job.{FeatureGenJobContext, FeatureGenSpec}
-
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.annotations.Test
 
-class TestFeatureGenSpecParser{
+class TestFeatureGenSpecParser extends TestNGSuite{
 
   @Test(description = "test feature gen spec parser")
   def featureGenSpecParserTest(): Unit = {

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/join/algorithms/TestJoinConditionBuilder.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/join/algorithms/TestJoinConditionBuilder.scala
@@ -5,7 +5,7 @@ import com.linkedin.feathr.offline.TestFeathr
 import org.apache.spark.sql.functions.{expr, lit}
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.types.{DataTypes, FloatType, StringType, StructField, StructType}
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.testng.Assert._
 import org.testng.annotations.Test
 

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/join/algorithms/TestJoinKeyColumnsAppender.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/join/algorithms/TestJoinKeyColumnsAppender.scala
@@ -4,7 +4,7 @@ import com.linkedin.feathr.common.exception.FeathrFeatureJoinException
 import com.linkedin.feathr.offline.TestFeathr
 import org.apache.spark.sql.DataFrame
 import org.mockito.Mockito.{verify, when}
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.testng.annotations.Test
 
 class TestJoinKeyColumnsAppender extends TestFeathr with MockitoSugar {

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/join/algorithms/TestSparkJoin.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/join/algorithms/TestSparkJoin.scala
@@ -7,7 +7,7 @@ import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types._
 import org.mockito.Mockito.verifyNoInteractions
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.testng.Assert.assertEquals
 import org.testng.annotations.Test
 

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/join/algorithms/TestSparkSaltedJoin.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/join/algorithms/TestSparkSaltedJoin.scala
@@ -9,7 +9,7 @@ import org.apache.commons.math3.distribution.ZipfDistribution
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions._
 import org.mockito.Mockito.when
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.testng.Assert.{assertEquals, assertTrue}
 import org.testng.annotations._
 

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/join/workflow/TestAnchoredFeatureJoinStep.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/join/workflow/TestAnchoredFeatureJoinStep.scala
@@ -16,7 +16,7 @@ import org.testng.annotations.Test
 import org.testng.Assert._
 import org.mockito.Mockito._
 import org.mockito.ArgumentMatchers._
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 /**
  * Unit test class for [[AnchoredFeatureJoinStep]].

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/join/workflow/TestDerivedFeatureJoinStep.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/join/workflow/TestDerivedFeatureJoinStep.scala
@@ -10,7 +10,7 @@ import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Row}
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.testng.Assert._
 import org.testng.annotations.Test
 

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/logical/TestMultiStageJoinPlan.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/logical/TestMultiStageJoinPlan.scala
@@ -6,7 +6,7 @@ import com.linkedin.feathr.offline.anchored.feature.FeatureAnchorWithSource
 import com.linkedin.feathr.offline.config.{FeatureGroupsGenerator, FeatureJoinConfig}
 import com.linkedin.feathr.offline.derived.DerivedFeature
 import com.linkedin.feathr.offline.{ErasedEntityTaggedFeature, TestFeathr}
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.testng.Assert.{assertEquals, assertTrue}
 import org.testng.annotations.Test
 

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/source/dataloader/TestBatchDataLoader.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/source/dataloader/TestBatchDataLoader.scala
@@ -1,14 +1,8 @@
 package com.linkedin.feathr.offline.source.dataloader
 
-import com.linkedin.feathr.common.exception.FeathrInputDataException
 import com.linkedin.feathr.offline.TestFeathr
 import com.linkedin.feathr.offline.config.location.SimplePath
-import org.apache.hadoop.mapred.JobConf
-import org.apache.log4j.Logger
 import org.apache.spark.sql.Row
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{times, verify, when}
-import org.scalatestplus.mockito.MockitoSugar.mock
 import org.testng.Assert.assertEquals
 import org.testng.annotations.Test
 
@@ -16,6 +10,7 @@ import org.testng.annotations.Test
  * unit tests for [[BatchDataLoader]]
  */
 class TestBatchDataLoader extends TestFeathr {
+
   def escape(raw: String): String = {
     import scala.reflect.runtime.universe._
     Literal(Constant(raw)).toString
@@ -61,19 +56,4 @@ class TestBatchDataLoader extends TestFeathr {
     sqlContext.setConf("spark.feathr.inputFormat.csvOptions.sep", "")
   }
 
-  @Test(description = "Verify loadDataFrame with retry works", expectedExceptions = Array(classOf[FeathrInputDataException]))
-  def testRetry(): Unit = {
-    val path = SimplePath("anchor1-source")
-    val loader = mock[BatchDataLoader]
-    val log = mock[Logger]
-    when(loader.loadDataFrame()).thenCallRealMethod()
-    when(loader.loadDataFrameWithRetry(any(classOf[Map[String, String]]), any(classOf[JobConf]), any(classOf[Int]))).thenCallRealMethod()
-    when(loader.ss).thenReturn(ss)
-    when(loader.location).thenReturn(path)
-    when(loader.dataLoaderHandlers).thenReturn(List())
-    when(loader.log).thenReturn(log)
-    when(loader.MAX_DATA_LOAD_RETRY).thenReturn(2)
-    loader.loadDataFrame()
-    verify(loader, times(3)).loadDataFrameWithRetry(any(classOf[Map[String, String]]), any(classOf[JobConf]), any(classOf[Int]))
-  }
 }

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/source/dataloader/TestCaseInsensitiveGenericRecordWrapper.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/source/dataloader/TestCaseInsensitiveGenericRecordWrapper.scala
@@ -3,7 +3,7 @@ package com.linkedin.feathr.offline.source.dataloader
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper
 import org.apache.avro.generic.{GenericData, GenericRecord}
 import org.apache.avro.{AvroRuntimeException, Schema}
-import org.scalatest.Assertions.assertThrows
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.{assertEquals, assertFalse, assertTrue}
 import org.testng.annotations.Test
 
@@ -12,7 +12,7 @@ import scala.collection.JavaConverters._
 /**
  * unit test for CaseInsensitiveGenericRecordWrapper
  */
-class TestCaseInsensitiveGenericRecordWrapper{
+class TestCaseInsensitiveGenericRecordWrapper extends TestNGSuite{
 
   val record = createRecord()
   val childRecord = record.get("child").asInstanceOf[GenericRecord]

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/source/pathutil/TestPathChecker.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/source/pathutil/TestPathChecker.scala
@@ -9,7 +9,7 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.DataFrame
 import org.apache.hadoop.mapred.JobConf
 import org.mockito.Mockito.when
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.testng.Assert.{assertEquals, assertTrue}
 import org.testng.annotations.Test
 

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/source/pathutil/TestTimeBasedHdfsPathAnalyzer.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/source/pathutil/TestTimeBasedHdfsPathAnalyzer.scala
@@ -3,7 +3,7 @@ package com.linkedin.feathr.offline.source.pathutil
 import com.linkedin.feathr.common.DateTimeResolution
 import com.linkedin.feathr.offline.TestFeathr
 import org.mockito.Mockito._
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.testng.Assert.assertEquals
 import org.testng.annotations.Test
 

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/source/pathutil/TestTimeBasedHdfsPathGenerator.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/source/pathutil/TestTimeBasedHdfsPathGenerator.scala
@@ -3,7 +3,7 @@ package com.linkedin.feathr.offline.source.pathutil
 import com.linkedin.feathr.common.DateTimeResolution
 import com.linkedin.feathr.offline.{TestFeathr, TestUtils}
 import org.mockito.Mockito._
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.testng.Assert.assertEquals
 import org.testng.annotations.Test
 

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/swa/TestSlidingWindowFeatureUtils.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/swa/TestSlidingWindowFeatureUtils.scala
@@ -13,7 +13,7 @@ import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Row}
 import org.testng.Assert.{assertEquals, assertFalse, assertTrue}
 import org.testng.annotations._
-import org.scalatestplus.mockito.MockitoSugar.mock
+import org.scalatest.mockito.MockitoSugar.mock
 import org.mockito.Mockito.when
 
 import scala.collection.JavaConverters._

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/transformation/TestAnchorToDataSourceMapper.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/transformation/TestAnchorToDataSourceMapper.scala
@@ -8,7 +8,7 @@ import com.linkedin.feathr.offline.{TestFeathr, TestUtils}
 import org.apache.avro.Schema
 import org.apache.avro.generic.{GenericRecord, GenericRecordBuilder}
 import org.apache.spark.sql.Row
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.testng.Assert.assertEquals
 import org.testng.annotations.{AfterClass, Test}
 

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/transformation/TestDataFrameExt.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/transformation/TestDataFrameExt.scala
@@ -1,7 +1,7 @@
 package com.linkedin.feathr.offline.transformation
 
 import com.linkedin.feathr.offline.TestFeathr
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.testng.annotations.Test
 import com.linkedin.feathr.offline.transformation.DataFrameExt._
 import com.linkedin.feathr.offline.AssertFeatureUtils._

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/transformation/TestDefaultValueToColumnConverter.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/transformation/TestDefaultValueToColumnConverter.scala
@@ -5,7 +5,7 @@ import com.linkedin.feathr.common.FeatureValue
 import com.linkedin.feathr.common.exception.{FeathrException, FeathrFeatureTransformationException}
 import com.linkedin.feathr.offline.TestFeathr
 import org.mockito.Mockito.{verify, when}
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.testng.annotations.{DataProvider, Test}
 
 import java.{lang => jl, util => ju}

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/transformation/TestFDSConversionUtils.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/transformation/TestFDSConversionUtils.scala
@@ -2,7 +2,7 @@ package com.linkedin.feathr.offline.transformation
 
 import com.linkedin.feathr.common.exception.FeathrException
 import com.linkedin.feathr.offline.TestFeathr
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.testng.Assert.assertEquals
 import org.testng.annotations.{DataProvider, Test}
 

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/util/TestDataFrameSplitterMerger.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/util/TestDataFrameSplitterMerger.scala
@@ -8,9 +8,9 @@ import com.linkedin.feathr.offline.util.DataFrameSplitterMerger._
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import com.linkedin.feathr.offline.util.TestSplitMergeDataProvider._
+import org.scalatest.testng.TestNGSuite
 
-
-class TestDataFrameSplitterMerger {
+class TestDataFrameSplitterMerger extends TestNGSuite {
 
   /**
    * Test partitioning when NO nulls exist in column.

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/util/TestFDSConversionUtil.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/util/TestFDSConversionUtil.scala
@@ -8,7 +8,7 @@ import com.linkedin.feathr.offline.transformation.FDSConversionUtils
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.{GenericRow, GenericRowWithSchema}
 import org.apache.spark.sql.types._
-
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.{assertEquals, assertTrue}
 import org.testng.annotations.{DataProvider, Test}
 
@@ -16,7 +16,7 @@ import java.util
 import java.util.Collections
 import scala.collection.mutable
 
-class TestFDSConversionUtil {
+class TestFDSConversionUtil extends TestNGSuite {
 
   val EMPTY_STRING = ""
   val EXPECTED_DENSE_VECTOR_FDS_DATA_TYPE = ArrayType(FloatType, false)

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/util/TestPartitionLimiter.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/util/TestPartitionLimiter.scala
@@ -4,7 +4,7 @@ import com.linkedin.feathr.offline.TestFeathr
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.mockito.Mockito.when
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.testng.Assert.assertEquals
 import org.testng.annotations.{BeforeClass, DataProvider, Test}
 

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/util/datetime/TestDateTimeInterval.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/util/datetime/TestDateTimeInterval.scala
@@ -3,14 +3,14 @@ package com.linkedin.feathr.offline.util.datetime
 import com.linkedin.feathr.common.DateTimeResolution
 import com.linkedin.feathr.offline.TestUtils.{createDailyInterval, createHourlyInterval}
 import com.linkedin.feathr.offline.util.datetime.OfflineDateTimeUtils.createTimeFromString
-
+import org.scalatest.testng.TestNGSuite
 import org.testng.annotations.Test
 import org.testng.Assert.{assertEquals, assertFalse, assertTrue}
 
 /**
  * unit tests for [[DateTimeInterval]]
  */
-class TestDateTimeInterval {
+class TestDateTimeInterval extends TestNGSuite {
 
   @Test(description = "test creation of DateTimeInterval")
   def testCreation(): Unit = {

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/util/datetime/TestDateTimePeriod.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/util/datetime/TestDateTimePeriod.scala
@@ -2,14 +2,14 @@ package com.linkedin.feathr.offline.util.datetime
 
 import com.linkedin.feathr.common.DateTimeResolution
 import com.linkedin.feathr.common.exception.FeathrConfigException
-
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.annotations.Test
 
 /**
  * A unit test class for DateTimePeriod.
  */
-class TestDateTimePeriod {
+class TestDateTimePeriod extends TestNGSuite {
 
   /**
    * Unit test for parsing days.

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/util/datetime/TestOfflineDateTimeUtils.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/util/datetime/TestOfflineDateTimeUtils.scala
@@ -3,7 +3,7 @@ package com.linkedin.feathr.offline.util.datetime
 import com.linkedin.feathr.common.exception.FeathrConfigException
 import com.linkedin.feathr.common.{DateParam, DateTimeResolution}
 import com.linkedin.feathr.offline.TestUtils.{createDailyInterval, createHourlyInterval}
-import org.scalatest.Assertions.assertThrows
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.annotations.Test
 
@@ -11,7 +11,7 @@ import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import java.time.{Duration, LocalDate, ZoneId, ZonedDateTime}
 
-class TestOfflineDateTimeUtils {
+class TestOfflineDateTimeUtils extends TestNGSuite {
 
   @Test(description = "test dateRange for creating datepartition filter expression")
   def testDateRange(): Unit = {


### PR DESCRIPTION
This reverts commit dce37663c74d8ee72abd83e3830fa3a31c6fa2bd.

## Description
 
Reverting the missing data retry as it may increase 'time-to-fail' and success of retry resolving actual upstream data issue could be remote.  We will add an option to skip missing feature instead of fail the job.
 
 