### PR TITLE
Auto add resolution when timePartitionPattern is present

### DIFF
--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/source/accessor/DataSourceAccessor.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/source/accessor/DataSourceAccessor.scala
@@ -62,7 +62,7 @@ private[offline] object DataSourceAccessor {
       new NonTimeBasedDataSourceAccessor(ss, dataLoaderFactory, source, expectDatumType)
     } else {
       import scala.util.control.Breaks._
-      
+
       val timeInterval = dateIntervalOpt.get
       var dataAccessorOpt: Option[DataSourceAccessor] = None
       breakable {
@@ -106,7 +106,8 @@ private[offline] object DataSourceAccessor {
     val partitionLimiter = new PartitionLimiter(ss)
     val pathAnalyzer = new TimeBasedHdfsPathAnalyzer(pathChecker, dataLoaderHandlers)
     val fileName = new File(source.path).getName
-    if (source.timePartitionPattern.isDefined) {
+    if ((source.sourceType == SourceFormatType.TIME_PATH || source.sourceType == SourceFormatType.TIME_SERIES_PATH)
+      && source.timePartitionPattern.isDefined) {
       // case 1: the timePartitionPattern exists
       val pathInfo = pathAnalyzer.analyze(source.path, source.timePartitionPattern.get)
       PathPartitionedTimeSeriesSourceAccessor(
@@ -147,7 +148,7 @@ private[offline] object DataSourceAccessor {
  */
 private[offline] case class DataAccessorHandler(
   validatePath: String => Boolean,
-  getAccessor: 
+  getAccessor:
   (
     SparkSession,
     DataSource,

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/source/pathutil/TimeBasedHdfsPathAnalyzer.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/source/pathutil/TimeBasedHdfsPathAnalyzer.scala
@@ -11,6 +11,10 @@ import com.linkedin.feathr.offline.source.dataloader.DataLoaderHandler
  */
 private[offline] class TimeBasedHdfsPathAnalyzer(pathChecker: PathChecker, dataLoaderHandlers: List[DataLoaderHandler]) {
 
+  val dailyFolder = "daily/"
+  val hourlyFolder = "hourly/"
+  val dailyPattern = "yyyy/MM/dd"
+  val hourlyPattern = "yyyy/MM/dd/HH"
   /**
    * check whether the given path is daily or hourly partitioned.
    *
@@ -22,10 +26,6 @@ private[offline] class TimeBasedHdfsPathAnalyzer(pathChecker: PathChecker, dataL
    * @return a PathInfo object to show how the data source is partitioned.
    */
   def analyze(filePath: String): PathInfo = {
-    val dailyFolder = "daily/"
-    val hourlyFolder = "hourly/"
-    val dailyPattern = "yyyy/MM/dd"
-    val hourlyPattern = "yyyy/MM/dd/HH"
     val fileFolder = if (filePath.endsWith("/")) filePath else filePath + "/"
 
     var pathInfoOpt: Option[PathInfo] = None // Used to store the pathInfo of any file caught by data loader handlers.
@@ -36,7 +36,7 @@ private[offline] class TimeBasedHdfsPathAnalyzer(pathChecker: PathChecker, dataL
         for(dataLoaderHandler <- dataLoaderHandlers) {
           if (dataLoaderHandler.validatePath(fileFolder)) {
             pathInfoOpt = Some(PathInfo(fileFolder, DateTimeResolution.DAILY, dailyPattern))
-          } 
+          }
         }
       }
     }
@@ -70,7 +70,18 @@ private[offline] class TimeBasedHdfsPathAnalyzer(pathChecker: PathChecker, dataL
   def analyze(filePath: String, timePartitionPattern: String): PathInfo = {
     val basePath = if (filePath.endsWith("/") || filePath.endsWith("=")) filePath else filePath + "/"
     val dateTimeResolution = OfflineDateTimeUtils.getDateTimeResolutionFromPattern(timePartitionPattern)
-    PathInfo(basePath, dateTimeResolution, timePartitionPattern)
+    if (basePath.endsWith(dailyFolder)) {
+      PathInfo(basePath, dateTimeResolution, timePartitionPattern)
+    } else if (basePath.endsWith(hourlyFolder)) {
+      PathInfo(basePath, dateTimeResolution, timePartitionPattern)
+    } else if (pathChecker.exists(basePath + dailyFolder)) {
+      PathInfo(basePath + dailyFolder, dateTimeResolution, timePartitionPattern)
+    } else if (pathChecker.exists(basePath + hourlyFolder)) {
+      PathInfo(basePath + hourlyFolder, dateTimeResolution, timePartitionPattern)
+    } else {
+      // Daily data can be Orc/Hive data following in HomeDir/datepartition=yyyy-MM-dd-00
+      PathInfo(basePath + "datepartition=", dateTimeResolution, "yyyy-MM-dd-00")
+    }
   }
 }
 

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/source/pathutil/TimeBasedHdfsPathAnalyzer.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/source/pathutil/TimeBasedHdfsPathAnalyzer.scala
@@ -79,7 +79,8 @@ private[offline] class TimeBasedHdfsPathAnalyzer(pathChecker: PathChecker, dataL
     } else if (pathChecker.exists(basePath + hourlyFolder)) {
       PathInfo(basePath + hourlyFolder, dateTimeResolution, timePartitionPattern)
     } else {
-      PathInfo(basePath, dateTimeResolution, timePartitionPattern)
+      // Daily data can be Orc/Hive data following in HomeDir/datepartition=yyyy-MM-dd-00
+      PathInfo(basePath + "datepartition=", dateTimeResolution, timePartitionPattern)
     }
   }
 }

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/source/pathutil/TimeBasedHdfsPathAnalyzer.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/source/pathutil/TimeBasedHdfsPathAnalyzer.scala
@@ -79,8 +79,7 @@ private[offline] class TimeBasedHdfsPathAnalyzer(pathChecker: PathChecker, dataL
     } else if (pathChecker.exists(basePath + hourlyFolder)) {
       PathInfo(basePath + hourlyFolder, dateTimeResolution, timePartitionPattern)
     } else {
-      // Daily data can be Orc/Hive data following in HomeDir/datepartition=yyyy-MM-dd-00
-      PathInfo(basePath + "datepartition=", dateTimeResolution, "yyyy-MM-dd-00")
+      PathInfo(basePath, dateTimeResolution, timePartitionPattern)
     }
   }
 }

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/FeatureGenIntegTest.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/FeatureGenIntegTest.scala
@@ -21,7 +21,19 @@ class FeatureGenIntegTest extends FeathrIntegTest {
   private val defaultSwaSource =
     """
       |  swaSource: {
-      |    location: { path: "generation/daily/" }
+      |    location: { path: "generation/daily" }
+      |    timePartitionPattern: "yyyy/MM/dd"
+      |    timeWindowParameters: {
+      |      timestampColumn: "timestamp"
+      |      timestampColumnFormat: "yyyy-MM-dd"
+      |    }
+      |  }
+    """.stripMargin
+
+  private val malformedDefaultSwaSource =
+    """
+      |  swaSource: {
+      |    location: { path: "generation/daily" }
       |    timePartitionPattern: "yyyy/MM/dd"
       |    timeWindowParameters: {
       |      timestampColumn: "timestamp"
@@ -898,7 +910,7 @@ class FeatureGenIntegTest extends FeathrIntegTest {
     val swaFeatureDefConfig =
       s"""
          |sources: {
-         |  ${defaultSwaSource}
+         |  ${malformedDefaultSwaSource}
          |}
          |anchors: {
          |  swaAnchorWithKeyExtractor: {

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/source/pathutil/TestTimeBasedHdfsPathAnalyzer.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/source/pathutil/TestTimeBasedHdfsPathAnalyzer.scala
@@ -85,7 +85,7 @@ class TestTimeBasedHdfsPathAnalyzer extends TestFeathr with MockitoSugar {
       pathAnalyzer.analyze("resources/generation/", "yyyy/MM/dd/HH"),
       PathInfo("resources/generation/hourly/", DateTimeResolution.HOURLY, "yyyy/MM/dd/HH"))
     assertEquals(
-      pathAnalyzer.analyze("test/resources/generation/datepartition=", "yyyy-MM-dd-00"),
+      pathAnalyzer.analyze("test/resources/generation/", "yyyy-MM-dd-00"),
       PathInfo("test/resources/generation/datepartition=", DateTimeResolution.DAILY, "yyyy-MM-dd-00"))
   }
 }

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/source/pathutil/TestTimeBasedHdfsPathAnalyzer.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/source/pathutil/TestTimeBasedHdfsPathAnalyzer.scala
@@ -85,7 +85,7 @@ class TestTimeBasedHdfsPathAnalyzer extends TestFeathr with MockitoSugar {
       pathAnalyzer.analyze("resources/generation/", "yyyy/MM/dd/HH"),
       PathInfo("resources/generation/hourly/", DateTimeResolution.HOURLY, "yyyy/MM/dd/HH"))
     assertEquals(
-      pathAnalyzer.analyze("test/resources/generation/", "yyyy-MM-dd-00"),
+      pathAnalyzer.analyze("test/resources/generation/datepartition=", "yyyy-MM-dd-00"),
       PathInfo("test/resources/generation/datepartition=", DateTimeResolution.DAILY, "yyyy-MM-dd-00"))
   }
 }

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/source/pathutil/TestTimeBasedHdfsPathAnalyzer.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/source/pathutil/TestTimeBasedHdfsPathAnalyzer.scala
@@ -73,18 +73,19 @@ class TestTimeBasedHdfsPathAnalyzer extends TestFeathr with MockitoSugar {
   def tetAnalyzePathWithTimePartitionPattern(): Unit = {
     val mockPathChecker = mock[PathChecker]
     val pathAnalyzer = new TimeBasedHdfsPathAnalyzer(mockPathChecker, List())
+    when(mockPathChecker.exists("src/test/resources/generation/daily/")).thenReturn(true)
+    when(mockPathChecker.exists("resources/generation/hourly/")).thenReturn(true)
     assertEquals(
       pathAnalyzer.analyze("src/test/resources/generation/", "yyyy/MM/dd"),
-      PathInfo("src/test/resources/generation/", DateTimeResolution.DAILY, "yyyy/MM/dd"))
+      PathInfo("src/test/resources/generation/daily/", DateTimeResolution.DAILY, "yyyy/MM/dd"))
     assertEquals(
       pathAnalyzer.analyze("src/test/resources/generation/", "yyyy/MM/dd"),
-      PathInfo("src/test/resources/generation/", DateTimeResolution.DAILY, "yyyy/MM/dd"))
+      PathInfo("src/test/resources/generation/daily/", DateTimeResolution.DAILY, "yyyy/MM/dd"))
     assertEquals(
-      pathAnalyzer.analyze("src/test/resources/generation/", "yyyy/MM/dd/HH"),
-      PathInfo("src/test/resources/generation/", DateTimeResolution.HOURLY, "yyyy/MM/dd/HH"))
+      pathAnalyzer.analyze("resources/generation/", "yyyy/MM/dd/HH"),
+      PathInfo("resources/generation/hourly/", DateTimeResolution.HOURLY, "yyyy/MM/dd/HH"))
     assertEquals(
-      pathAnalyzer.analyze("src/test/resources/generation/datepartition=", "yyyy-MM-dd-00"),
-      PathInfo("src/test/resources/generation/datepartition=", DateTimeResolution.DAILY, "yyyy-MM-dd-00"))
-    verifyNoMoreInteractions(mockPathChecker)
+      pathAnalyzer.analyze("test/resources/generation/", "yyyy-MM-dd-00"),
+      PathInfo("test/resources/generation/datepartition=", DateTimeResolution.DAILY, "yyyy-MM-dd-00"))
   }
 }


### PR DESCRIPTION
When timePartitionPattern is present, the pathAnalyzer does not add the daily/hourly suffix, if not present.
In this PR, we fix that issue.