### PR TITLE
Add optional retry mechanism if data loading fails

### DIFF
--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/generation/DataFrameFeatureGenerator.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/generation/DataFrameFeatureGenerator.scala
@@ -11,13 +11,14 @@ import com.linkedin.feathr.offline.derived.strategies.{DerivationStrategies, Row
 import com.linkedin.feathr.offline.derived.{DerivedFeature, DerivedFeatureEvaluator}
 import com.linkedin.feathr.offline.evaluator.DerivedFeatureGenStage
 import com.linkedin.feathr.offline.job.FeatureJoinJob.FeatureName
-import com.linkedin.feathr.offline.job.{FeatureGenSpec, FeatureTransformation}
+import com.linkedin.feathr.offline.job.{FeatureGenSpec, FeatureTransformation, LocalFeatureJoinJob}
 import com.linkedin.feathr.offline.logical.{FeatureGroups, MultiStageJoinPlan, MultiStageJoinPlanner}
 import com.linkedin.feathr.offline.mvel.plugins.FeathrExpressionExecutionContext
 import com.linkedin.feathr.offline.source.accessor.DataPathHandler
 import com.linkedin.feathr.offline.source.dataloader.DataLoaderHandler
 import com.linkedin.feathr.offline.transformation.AnchorToDataSourceMapper
 import com.linkedin.feathr.offline.util.{AnchorUtils, FeathrUtils}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
 /**
@@ -76,6 +77,8 @@ private[offline] class DataFrameFeatureGenerator(logicalPlan: MultiStageJoinPlan
     val featureToDefaultValueMap = getDefaultValues(allRequiredFeatureAnchorWithSourceAndTime.values.toSeq)
     val featureToTypeConfigMap = getFeatureTypes(allRequiredFeatureAnchorWithSourceAndTime.values.toSeq)
 
+    val shouldSkipFeature = FeathrUtils.getFeathrJobParam(ss.sparkContext.getConf, FeathrUtils.SKIP_MISSING_FEATURE).toBoolean
+
     // 4. Calculate anchored features
     val allStageFeatures = joinStages.flatMap {
       case (_: Seq[Int], featureNames: Seq[String]) =>
@@ -88,12 +91,18 @@ private[offline] class DataFrameFeatureGenerator(logicalPlan: MultiStageJoinPlan
           .map(f => (f._1, (offline.FeatureDataFrame(f._2.transformedResult.df, f._2.transformedResult.inferredFeatureTypes), f._2.joinKey)))
     }.toMap
 
-    // 5. Group features based on grouping specified in output processors
-    val updatedAllStageFeatures = allStageFeatures.filter(keyValue => !keyValue._2._1.df.isEmpty)
+    // Update features based on skip missing feature flag and empty dataframe
+    val updatedAllStageFeatures = if (shouldSkipFeature || (ss.sparkContext.isLocal &&
+      SQLConf.get.getConf(LocalFeatureJoinJob.SKIP_MISSING_FEATURE))) {
+      allStageFeatures.filter(keyValue => !keyValue._2._1.df.isEmpty)
+    } else allStageFeatures
+
     val (updatedFeatureGroups, updatedKeyTaggedFeatures) = FeatureGroupsUpdater().getUpdatedFeatureGroups(featureGroups,
       updatedAllStageFeatures, keyTaggedFeatures)
 
     val updatedLogicalPlan = MultiStageJoinPlanner().getLogicalPlan(updatedFeatureGroups, updatedKeyTaggedFeatures)
+
+    // 5. Group features based on grouping specified in output processors
     val groupedAnchoredFeatures = featureGenFeatureGrouper.group(updatedAllStageFeatures, featureGenSpec.getOutputProcessorConfigs,
       updatedFeatureGroups.allDerivedFeatures)
 

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/generation/DataFrameFeatureGenerator.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/generation/DataFrameFeatureGenerator.scala
@@ -68,6 +68,8 @@ private[offline] class DataFrameFeatureGenerator(logicalPlan: MultiStageJoinPlan
     val anchorDFRDDMap = anchorToDataFrameMapper.getAnchorDFMapForGen(ss, requiredRegularFeatureAnchorsWithTime, Some(incrementalAggContext), failOnMissingPartition)
 
     val updatedAnchorDFRDDMap = anchorDFRDDMap.filter(anchorEntry => anchorEntry._2.isDefined).map(anchorEntry => anchorEntry._1 -> anchorEntry._2.get)
+
+    // It could happen that all features are skipped, then return empty result
     if(updatedAnchorDFRDDMap.isEmpty) return Map()
 
     // 3. Load user specified default values and feature types, if any.

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/job/LocalFeatureJoinJob.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/job/LocalFeatureJoinJob.scala
@@ -23,9 +23,15 @@ object LocalFeatureJoinJob {
   val ss: SparkSession = createSparkSession(enableHiveSupport = true)
   val SKIP_MISSING_FEATURE = SQLConf
     .buildConf("spark.feathr.skip.missing.feature")
-    .doc("Whether to use the V2 implementation, which should have better performance.")
+    .doc("Whether to skip features if data is missing.")
     .booleanConf
     .createWithDefault(false)
+
+  val MAX_DATA_LOAD_RETRY = SQLConf
+    .buildConf("spark.feathr.max.data.load.retry")
+    .doc("Number of retries if data is missing.")
+    .intConf
+    .createWithDefault(0)
 
   /**
    * local debug API, used in unit test and local debug

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/transformation/AnchorToDataSourceMapper.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/transformation/AnchorToDataSourceMapper.scala
@@ -141,8 +141,6 @@ private[offline] class AnchorToDataSourceMapper(dataPathHandlers: List[DataPathH
     catch {// todo - Add this functionality to only specific exception types and not for all error types.
       case e: Exception => if (shouldSkipFeature || (ss.sparkContext.isLocal &&
         SQLConf.get.getConf(LocalFeatureJoinJob.SKIP_MISSING_FEATURE))) {
-        logger.warn(s"shouldSkipFeature is " + shouldSkipFeature + "spark is session " + ss.sparkContext.isLocal + "local skip feature is "
-          + SQLConf.get.getConf(LocalFeatureJoinJob.SKIP_MISSING_FEATURE))
         ss.emptyDataFrame
       } else throw e
     }
@@ -201,10 +199,7 @@ private[offline] class AnchorToDataSourceMapper(dataPathHandlers: List[DataPathH
             dataPathHandlers = dataPathHandlers))
         } catch {
           case e: Exception => if (shouldSkipFeature || (ss.sparkContext.isLocal &&
-            SQLConf.get.getConf(LocalFeatureJoinJob.SKIP_MISSING_FEATURE)))
-            {
-              logger.warn(s"shouldSkipFeature is " + shouldSkipFeature + "spark is session " + ss.sparkContext.isLocal + "local skip feature is "
-                + SQLConf.get.getConf(LocalFeatureJoinJob.SKIP_MISSING_FEATURE))
+            SQLConf.get.getConf(LocalFeatureJoinJob.SKIP_MISSING_FEATURE))) {
               None
             } else throw e
         }

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/transformation/AnchorToDataSourceMapper.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/transformation/AnchorToDataSourceMapper.scala
@@ -141,6 +141,8 @@ private[offline] class AnchorToDataSourceMapper(dataPathHandlers: List[DataPathH
     catch {// todo - Add this functionality to only specific exception types and not for all error types.
       case e: Exception => if (shouldSkipFeature || (ss.sparkContext.isLocal &&
         SQLConf.get.getConf(LocalFeatureJoinJob.SKIP_MISSING_FEATURE))) {
+        logger.warn(s"shouldSkipFeature is " + shouldSkipFeature + "spark is session " + ss.sparkContext.isLocal + "local skip feature is "
+          + SQLConf.get.getConf(LocalFeatureJoinJob.SKIP_MISSING_FEATURE))
         ss.emptyDataFrame
       } else throw e
     }
@@ -199,7 +201,10 @@ private[offline] class AnchorToDataSourceMapper(dataPathHandlers: List[DataPathH
             dataPathHandlers = dataPathHandlers))
         } catch {
           case e: Exception => if (shouldSkipFeature || (ss.sparkContext.isLocal &&
-            SQLConf.get.getConf(LocalFeatureJoinJob.SKIP_MISSING_FEATURE))) {
+            SQLConf.get.getConf(LocalFeatureJoinJob.SKIP_MISSING_FEATURE)))
+            {
+              logger.warn(s"shouldSkipFeature is " + shouldSkipFeature + "spark is session " + ss.sparkContext.isLocal + "local skip feature is "
+                + SQLConf.get.getConf(LocalFeatureJoinJob.SKIP_MISSING_FEATURE))
               None
             } else throw e
         }

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/transformation/AnchorToDataSourceMapper.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/transformation/AnchorToDataSourceMapper.scala
@@ -208,7 +208,6 @@ private[offline] class AnchorToDataSourceMapper(dataPathHandlers: List[DataPathH
               None
             } else throw e
         }
-
         anchors.map(anchor => (anchor, timeSeriesSource))
     })
   }

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/transformation/AnchorToDataSourceMapper.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/transformation/AnchorToDataSourceMapper.scala
@@ -1,5 +1,7 @@
 package com.linkedin.feathr.offline.transformation
 
+import com.linkedin.feathr.common.configObj.configbuilder.FeatureGenConfigBuilder
+
 import java.time.Duration
 import com.linkedin.feathr.common.{DateParam, DateTimeResolution}
 import com.linkedin.feathr.offline.source.SourceFormatType._
@@ -15,6 +17,7 @@ import com.linkedin.feathr.offline.source.pathutil.{PathChecker, TimeBasedHdfsPa
 import com.linkedin.feathr.offline.swa.SlidingWindowFeatureUtils
 import com.linkedin.feathr.offline.util.{FeathrUtils, SourceUtils}
 import com.linkedin.feathr.offline.util.datetime.{DateTimeInterval, OfflineDateTimeUtils}
+import org.apache.log4j.Logger
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
@@ -22,6 +25,7 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
  * The primary responsibility of this class is to Map the anchored features to its DataFrame.
  */
 private[offline] class AnchorToDataSourceMapper(dataPathHandlers: List[DataPathHandler]) {
+  private val logger = Logger.getLogger(classOf[AnchorToDataSourceMapper])
 
   /**
    * Get basic anchored feature to datasource mapping for feature join use case.
@@ -136,7 +140,11 @@ private[offline] class AnchorToDataSourceMapper(dataPathHandlers: List[DataPathH
     }
     catch {// todo - Add this functionality to only specific exception types and not for all error types.
       case e: Exception => if (shouldSkipFeature || (ss.sparkContext.isLocal &&
-        SQLConf.get.getConf(LocalFeatureJoinJob.SKIP_MISSING_FEATURE))) ss.emptyDataFrame else throw e
+        SQLConf.get.getConf(LocalFeatureJoinJob.SKIP_MISSING_FEATURE))) {
+        logger.warn(s"shouldSkipFeature is " + shouldSkipFeature + "spark is session " + ss.sparkContext.isLocal + "local skip feature is "
+          + SQLConf.get.getConf(LocalFeatureJoinJob.SKIP_MISSING_FEATURE))
+        ss.emptyDataFrame
+      } else throw e
     }
   }
 
@@ -193,7 +201,12 @@ private[offline] class AnchorToDataSourceMapper(dataPathHandlers: List[DataPathH
             dataPathHandlers = dataPathHandlers))
         } catch {
           case e: Exception => if (shouldSkipFeature || (ss.sparkContext.isLocal &&
-            SQLConf.get.getConf(LocalFeatureJoinJob.SKIP_MISSING_FEATURE))) None else throw e
+            SQLConf.get.getConf(LocalFeatureJoinJob.SKIP_MISSING_FEATURE)))
+            {
+              logger.warn(s"shouldSkipFeature is " + shouldSkipFeature + "spark is session " + ss.sparkContext.isLocal + "local skip feature is "
+                + SQLConf.get.getConf(LocalFeatureJoinJob.SKIP_MISSING_FEATURE))
+              None
+            } else throw e
         }
 
         anchors.map(anchor => (anchor, timeSeriesSource))

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/util/FeathrUtils.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/util/FeathrUtils.scala
@@ -39,6 +39,8 @@ private[offline] object FeathrUtils {
   val SPARK_JOIN_MAX_PARALLELISM = "max.parallelism"
   val CHECKPOINT_OUTPUT_PATH = "checkpoint.dir"
   val SPARK_JOIN_MIN_PARALLELISM = "min.parallelism"
+  val MAX_DATA_LOAD_RETRY = "max.data.load.retry"
+  val DATA_LOAD_WAIT_IN_MS = "data.load.wait.in.ms"
 
   val defaultParams: Map[String, String] = Map(
     ENABLE_DEBUG_OUTPUT -> "false",
@@ -50,6 +52,8 @@ private[offline] object FeathrUtils {
     SEQ_JOIN_ARRAY_EXPLODE_ENABLED -> "true",
     ENABLE_SALTED_JOIN -> "false",
     SKIP_MISSING_FEATURE -> "false",
+    MAX_DATA_LOAD_RETRY-> "0",
+    DATA_LOAD_WAIT_IN_MS-> "1",
     // If one key appears more than 0.02% in the dataset, we will salt this join key and split them into multiple partitions
     // This is an empirical value
     SALTED_JOIN_FREQ_ITEM_THRESHOLD -> "0.0002",

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/SlidingWindowAggIntegTest.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/SlidingWindowAggIntegTest.scala
@@ -281,7 +281,7 @@ class SlidingWindowAggIntegTest extends FeathrIntegTest {
       """
         |sources: {
         |  swaSource: {
-        |    location: { path: "slidingWindowAgg/localSWDefaultTest/daily" }
+        |    location: { path: "slidingWindowAgg/localSWADefaultTest/daily" }
         |    timePartitionPattern: "yyyy/MM/dd"
         |    timeWindowParameters: {
         |      timestampColumn: "timestamp"

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/job/TestTimeBasedJoin.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/job/TestTimeBasedJoin.scala
@@ -20,7 +20,7 @@ class TestTimeBasedJoin extends TestFeathr {
   def testStartEndDatePath(): Unit = {
     val inputData1 = InputData("/test/path/", SourceFormatType.TIME_PATH, startDate = Some("20170908"), endDate = Some("20170910"))
     val pathList11 = getPathList(inputData1.sourceType, inputData1.inputPath, ss, inputData1.dateParam, dataLoaderHandlers=List())
-    val actualPathList = List("/test/path/datepartition=2017-09-08-00", "/test/path/datepartition=2017-09-09-00", "/test/path/datepartition=2017-09-10-00")
+    val actualPathList = List("/test/path/2017/09/08", "/test/path/2017/09/09", "/test/path/2017/09/10")
     assert(pathList11 == actualPathList)
   }
 
@@ -75,7 +75,7 @@ class TestTimeBasedJoin extends TestFeathr {
 
     val featureDataRelative2 = InputData("FEATHR_TEST_ONLY/path/", SourceFormatType.TIME_PATH, startDate = Some("20180227"), endDate = Some("20180227"))
 
-    val pathListRelative = 
+    val pathListRelative =
     getPathList(featureDataRelative.sourceType, featureDataRelative.inputPath, ss, featureDataRelative.dateParam, targetDate=Some(observationStartDate), dataLoaderHandlers=List())
     val pathListRelative2 = getPathList(featureDataRelative2.sourceType, featureDataRelative2.inputPath, ss, featureDataRelative2.dateParam,dataLoaderHandlers=List())
 
@@ -86,7 +86,7 @@ class TestTimeBasedJoin extends TestFeathr {
     val startDate = "20180225"
     val endDate = "20180225"
     val featureDataSpecific = InputData("FEATHR_TEST_ONLY/path/", SourceFormatType.TIME_PATH, startDate = Some(startDate), endDate = Some(endDate))
-    val pathListSpecific = 
+    val pathListSpecific =
     getPathList(featureDataSpecific.sourceType, featureDataSpecific.inputPath, ss, featureDataSpecific.dateParam, targetDate=Some(observationStartDate), dataLoaderHandlers=List())
     val pathListSpecific2 = getPathList(featureDataSpecific.sourceType, featureDataSpecific.inputPath, ss, featureDataSpecific.dateParam, dataLoaderHandlers=List())
 

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/source/dataloader/TestBatchDataLoader.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/source/dataloader/TestBatchDataLoader.scala
@@ -1,8 +1,11 @@
 package com.linkedin.feathr.offline.source.dataloader
 
+import com.linkedin.feathr.common.exception.{FeathrConfigException, FeathrInputDataException}
 import com.linkedin.feathr.offline.TestFeathr
 import com.linkedin.feathr.offline.config.location.SimplePath
+import com.linkedin.feathr.offline.job.LocalFeatureJoinJob
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.internal.SQLConf
 import org.testng.Assert.assertEquals
 import org.testng.annotations.Test
 
@@ -32,6 +35,20 @@ class TestBatchDataLoader extends TestFeathr {
       Row("9", "banana", "4", "4", "0.4")
     )
     assertEquals(df.collect(), expectedRows)
+  }
+
+  /**
+   * Test the batch loader retries before failing.
+   */
+  @Test(expectedExceptions = Array(classOf[FeathrInputDataException]),
+    expectedExceptionsMessageRegExp = ".* after 3 retries and retry time of 1ms.*")
+  def testRetry(): Unit = {
+    SQLConf.get.setConf(LocalFeatureJoinJob.MAX_DATA_LOAD_RETRY, 3)
+    val path = "anchor11-source.csv"
+    val batchDataLoader = new BatchDataLoader(ss, location = SimplePath(path), List())
+    val df = batchDataLoader.loadDataFrame()
+    df.show()
+    SQLConf.get.setConf(LocalFeatureJoinJob.MAX_DATA_LOAD_RETRY, 0)
   }
 
   @Test(description = "test loading dataframe with BatchDataLoader by specifying delimiter")

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/source/pathutil/TestTimeBasedHdfsPathAnalyzer.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/source/pathutil/TestTimeBasedHdfsPathAnalyzer.scala
@@ -62,11 +62,8 @@ class TestTimeBasedHdfsPathAnalyzer extends TestFeathr with MockitoSugar {
     val mockPathChecker = mock[PathChecker]
     val pathAnalyzer = new TimeBasedHdfsPathAnalyzer(mockPathChecker, List())
     assertEquals(
-      pathAnalyzer.analyze("src/test/resources/datePartitionSource"),
-      PathInfo("src/test/resources/datePartitionSource/datepartition=", DateTimeResolution.DAILY, "yyyy-MM-dd-00"))
-    verify(mockPathChecker).exists("src/test/resources/datePartitionSource/daily/")
-    verify(mockPathChecker).exists("src/test/resources/datePartitionSource/hourly/")
-    verifyNoMoreInteractions(mockPathChecker)
+      pathAnalyzer.analyze("dalids://src/test/resources/datePartitionSource"),
+      PathInfo("dalids://src/test/resources/datePartitionSource/", DateTimeResolution.DAILY, "yyyy/MM/dd"))
   }
 
   @Test(description = "test analyze with time partition pattern")
@@ -85,6 +82,5 @@ class TestTimeBasedHdfsPathAnalyzer extends TestFeathr with MockitoSugar {
     assertEquals(
       pathAnalyzer.analyze("src/test/resources/generation/datepartition=", "yyyy-MM-dd-00"),
       PathInfo("src/test/resources/generation/datepartition=", DateTimeResolution.DAILY, "yyyy-MM-dd-00"))
-    verifyNoMoreInteractions(mockPathChecker)
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.10.4-rc3
+version=0.10.4-rc4
 SONATYPE_AUTOMATIC_RELEASE=true
 POM_ARTIFACT_ID=feathr_2.12


### PR DESCRIPTION
1. Users can set the spark parameters:-
spark.feathr.max.data.load.retry > 0
spark.feathr.data.load.wait.in.ms > 1
and Feathr will retry to load the dataframe.
2. Fix test bugs caused by https://github.com/feathr-ai/feathr/pull/1027