### PR TITLE
Fix NPE of MVEL UDFs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,7 @@ project.ext.spec = [
         "avroUtil": "com.linkedin.avroutil1:helper-all:0.2.100",
         "azure": "com.microsoft.azure:azure-eventhubs-spark_2.12:2.3.21",
         'fastutil' : "it.unimi.dsi:fastutil:8.1.1",
-        'mvel' : "org.mvel:mvel2:2.2.8.Final",
+        'mvel' : "org.mvel:mvel2:2.4.7.Final",
         'protobuf' : "com.google.protobuf:protobuf-java:2.6.1",
         'guava' : "com.google.guava:guava:25.0-jre",
         'xbean' : "org.apache.xbean:xbean-asm6-shaded:4.10",

--- a/feathr-impl/src/main/java/com/linkedin/feathr/common/util/CoercionUtils.java
+++ b/feathr-impl/src/main/java/com/linkedin/feathr/common/util/CoercionUtils.java
@@ -314,7 +314,7 @@ public class CoercionUtils {
 
   private static <T> void checkNotNull(T item) {
     if (null == item) {
-      throw new RuntimeException("Unexpected null");
+      throw new NullPointerException("Unexpected null");
     }
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.10.4-rc4
+version=0.10.4-rc5
 SONATYPE_AUTOMATIC_RELEASE=true
 POM_ARTIFACT_ID=feathr_2.12


### PR DESCRIPTION
## Description
Fix NPE error for MVEL UDFs such as toNumeric(null). It should return null instead of throwing an exception.
This is done by throwing NPE directly for null instead of RuntimeException. The exception will be caught by MVEL evaluator and return null value gracefully.
Upgrade MVEL version.
 