### PR TITLE
Bump rc version number

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.10.4-rc5
+version=0.10.4-rc6
 SONATYPE_AUTOMATIC_RELEASE=true
 POM_ARTIFACT_ID=feathr_2.12


### PR DESCRIPTION
Bump version to 0.10.4-rc6 to consume https://github.com/feathr-ai/feathr/pull/1039/.