### PR TITLE
Fix nyc_taxi data utils bug in databricks path

### DIFF
--- a/docs/samples/nyc_taxi_demo.ipynb
+++ b/docs/samples/nyc_taxi_demo.ipynb
@@ -548,7 +548,7 @@
     "    data_source_path = data_file_path\n",
     "elif client.spark_runtime == \"databricks\" and is_databricks():\n",
     "    # If the notebook is running on databricks, we can use the same data path as the source.\n",
-    "    data_source_path = data_file_path.replace(\"/dbfs\", \"dbfs:\")\n",
+    "    data_source_path = data_file_path.replace(\"/dbfs\", \"dbfs:\", 1)\n",
     "else:\n",
     "    # Otherwise, upload the local file to the cloud storage (either dbfs or adls).\n",
     "    data_source_path = client.feathr_spark_launcher.upload_or_get_cloud_path(data_file_path)    "
@@ -1164,7 +1164,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "version": "3.8.16"
   },
   "vscode": {
    "interpreter": {

--- a/feathr_project/feathr/datasets/nyc_taxi.py
+++ b/feathr_project/feathr/datasets/nyc_taxi.py
@@ -70,12 +70,16 @@ def get_spark_df(
     if dst_path.suffix != src_filepath.suffix:
         local_cache_path = str(dst_path.joinpath(src_filepath.name))
 
+    # Databricks uses "dbfs:/" prefix for spark paths and "/dbfs/" prefix for python paths
     if is_databricks():
-        # Databricks uses "dbfs:/" prefix for spark paths
-        if not local_cache_path.startswith("dbfs:"):
+        # If local_cache_path is a python path, convert it to a spark path.
+        if local_cache_path.startswith("/dbfs/"):
+            local_cache_path = local_cache_path.replace("/dbfs", "dbfs:", 1)
+        # If local_cache_path is not a spark path, add the spark path prefix.
+        elif not local_cache_path.startswith("dbfs:"):
             local_cache_path = f"dbfs:/{local_cache_path.lstrip('/')}"
-        # Databricks uses "/dbfs/" prefix for python paths
-        python_local_cache_path = local_cache_path.replace("dbfs:", "/dbfs")
+
+        python_local_cache_path = local_cache_path.replace("dbfs:", "/dbfs", 1)
     # TODO add "if is_synapse()"
     else:
         python_local_cache_path = local_cache_path


### PR DESCRIPTION
Signed-off-by: Jun Ki Min <42475935+loomlike@users.noreply.github.com>

## Description
`nyc_taxi.get_spark_df` doesn't parses the `local_cache_path` argument correctly when it has "/dbfs/" prefix.
Previously, "/dbfs/myfile" is parsed as "dbfs:/dbfs/myfile", but it should be "dbfs:/myfile" instead.
This PR fixes this behavior.

## How was this PR tested?
<!--
Describe what testings you have done. If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added more unit test cases after the fix.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide UI screenshot, the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.