### PR TITLE
Bump python client and ui version to `0.10.4-rc5`

### DIFF
--- a/feathr_project/feathr/version.py
+++ b/feathr_project/feathr/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.4-rc1"
+__version__ = "0.10.4-rc5"
 
 def get_version():
     return __version__

--- a/feathr_project/setup.py
+++ b/feathr_project/setup.py
@@ -20,7 +20,7 @@ except IOError:
     print("Failed to load Feathr version file for packaging.",
           file=sys.stderr)
     # Temp workaround for conda build. For long term fix, Jay will need to update manifest.in file.
-    VERSION = "0.10.4-rc1"
+    VERSION = "0.10.4-rc5"
 
 VERSION = __version__  # noqa
 os.environ["FEATHR_VERSION"] = VERSION

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feathr-ui",
-  "version": "0.10.4-rc1",
+  "version": "0.10.4-rc5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "feathr-ui",
-      "version": "0.10.4-rc1",
+      "version": "0.10.4-rc5",
       "dependencies": {
         "@ant-design/icons": "^4.7.0",
         "@azure/msal-browser": "^2.24.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feathr-ui",
-  "version": "0.10.4-rc1",
+  "version": "0.10.4-rc5",
   "private": true,
   "scripts": {
     "start": "craco start",


### PR DESCRIPTION
## Description
<!--
Hey! Thank you for the contribution! Please go through https://github.com/feathr-ai/feathr/blob/main/docs/dev_guide/pull_request_guideline.md for more information.

Describe what changes to make and why you are making these changes.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

- Bump python client version to `0.10.4-rc5` so to mitigate org.everit.json.schema not found issue on cloud Sparks.
- Resolves #1041

## How was this PR tested?
<!--
Describe what testings you have done. If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI test

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide UI screenshot, the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
For users who are using v0.10 rc builds and apply the workaround for org.everit.json.schema not found, those manual workaround is no longer needed on client side and Spark side.