### PR TITLE
Invoke mvelContext for SimpleMvelDerivedFeatures

### DIFF
--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/derived/DerivedFeatureEvaluator.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/derived/DerivedFeatureEvaluator.scala
@@ -149,12 +149,12 @@ private[offline] object DerivedFeatureEvaluator {
       val keyedContextFeatureValues = contextFeatureValues.map(kv => (kv._1.getErasedTagFeatureName, kv._2))
       val resolvedInputArgs = linkedInputParams.map(taggedFeature => keyedContextFeatureValues.get(taggedFeature.getErasedTagFeatureName).flatMap(Option(_)))
       val derivedFunc = derivedFeature.getAsFeatureDerivationFunction match {
-        case a: MvelFeatureDerivationFunction =>
-          a.mvelContext = mvelContext
-          a
-        case b: SimpleMvelDerivationFunction =>
-          b.mvelContext = mvelContext
-          b
+        case mvelDerivedFunc: MvelFeatureDerivationFunction =>
+          mvelDerivedFunc.mvelContext = mvelContext
+          mvelDerivedFunc
+        case simpleMvelDerivedFunc: SimpleMvelDerivationFunction =>
+          simpleMvelDerivedFunc.mvelContext = mvelContext
+          simpleMvelDerivedFunc
         case func => func
       }
       val unlinkedOutput = derivedFunc.getFeatures(resolvedInputArgs)

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/derived/DerivedFeatureEvaluator.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/derived/DerivedFeatureEvaluator.scala
@@ -4,7 +4,7 @@ import com.linkedin.feathr.common.exception.{ErrorLabel, FeathrException}
 import com.linkedin.feathr.common.{FeatureDerivationFunction, FeatureTypeConfig}
 import com.linkedin.feathr.offline.client.DataFrameColName
 import com.linkedin.feathr.offline.client.plugins.{FeathrUdfPluginContext, FeatureDerivationFunctionAdaptor}
-import com.linkedin.feathr.offline.derived.functions.{MvelFeatureDerivationFunction, SQLFeatureDerivationFunction, SeqJoinDerivationFunction}
+import com.linkedin.feathr.offline.derived.functions.{MvelFeatureDerivationFunction, SQLFeatureDerivationFunction, SeqJoinDerivationFunction, SimpleMvelDerivationFunction}
 import com.linkedin.feathr.offline.derived.strategies._
 import com.linkedin.feathr.offline.join.algorithms.{SequentialJoinConditionBuilder, SparkJoinWithJoinCondition}
 import com.linkedin.feathr.offline.logical.FeatureGroups
@@ -149,9 +149,12 @@ private[offline] object DerivedFeatureEvaluator {
       val keyedContextFeatureValues = contextFeatureValues.map(kv => (kv._1.getErasedTagFeatureName, kv._2))
       val resolvedInputArgs = linkedInputParams.map(taggedFeature => keyedContextFeatureValues.get(taggedFeature.getErasedTagFeatureName).flatMap(Option(_)))
       val derivedFunc = derivedFeature.getAsFeatureDerivationFunction match {
-        case derivedFunc: MvelFeatureDerivationFunction =>
-          derivedFunc.mvelContext = mvelContext
-          derivedFunc
+        case a: MvelFeatureDerivationFunction =>
+          a.mvelContext = mvelContext
+          a
+        case b: SimpleMvelDerivationFunction =>
+          b.mvelContext = mvelContext
+          b
         case func => func
       }
       val unlinkedOutput = derivedFunc.getFeatures(resolvedInputArgs)

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/evaluator/transformation/BaseDerivedFeatureOperator.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/evaluator/transformation/BaseDerivedFeatureOperator.scala
@@ -71,9 +71,12 @@ object BaseDerivedFeatureOperator {
         // Sort by input feature name to be consistent with how the derivation function is created.
         val featureValues = contextFeatureValues.toSeq.sortBy(_._1).map(fv => Option(fv._2))
         val derivedFunc = derivationFunction match {
-          case derivedFunc: MvelFeatureDerivationFunction =>
-            derivedFunc.mvelContext = mvelContext
-            derivedFunc
+          case a: MvelFeatureDerivationFunction =>
+            a.mvelContext = mvelContext
+            a
+          case b: SimpleMvelDerivationFunction =>
+            b.mvelContext = mvelContext
+            b
           case func => func
         }
         val unlinkedOutput = derivedFunc.getFeatures(featureValues)

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/evaluator/transformation/BaseDerivedFeatureOperator.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/evaluator/transformation/BaseDerivedFeatureOperator.scala
@@ -71,12 +71,12 @@ object BaseDerivedFeatureOperator {
         // Sort by input feature name to be consistent with how the derivation function is created.
         val featureValues = contextFeatureValues.toSeq.sortBy(_._1).map(fv => Option(fv._2))
         val derivedFunc = derivationFunction match {
-          case a: MvelFeatureDerivationFunction =>
-            a.mvelContext = mvelContext
-            a
-          case b: SimpleMvelDerivationFunction =>
-            b.mvelContext = mvelContext
-            b
+          case mvelDerivedFunc: MvelFeatureDerivationFunction =>
+            mvelDerivedFunc.mvelContext = mvelContext
+            mvelDerivedFunc
+          case simpleMvelDerivedFunc: SimpleMvelDerivationFunction =>
+            simpleMvelDerivedFunc.mvelContext = mvelContext
+            simpleMvelDerivedFunc
           case func => func
         }
         val unlinkedOutput = derivedFunc.getFeatures(featureValues)


### PR DESCRIPTION
SimpleMvelDerived features should also be treated as an mvel feature, hence the mvel context should be invoked.