### PR TITLE
Remove PRs that will fail due to lack of credentials

### DIFF
--- a/.github/workflows/pull_request_push_test.yml
+++ b/.github/workflows/pull_request_push_test.yml
@@ -8,12 +8,12 @@ on:
       - "ui/**"
       - "**/README.md"
 
-  pull_request:
-    branches: [main]
-    paths-ignore:
-      - "docs/**"
-      - "ui/**"
-      - "**/README.md"
+  # pull_request:
+  #   branches: [main]
+  #   paths-ignore:
+  #     - "docs/**"
+  #     - "ui/**"
+  #     - "**/README.md"
 
   pull_request_target:
     branches: [main]


### PR DESCRIPTION
Currently if committers open a PR, it will run two tests - the one in `pull_request` and `pull_request_target`. The first set of tests will always fail since they don't have the required credentials. This should be disabled and later we should enforce policy to make sure the main branch always have passed tests.

Signed-off-by: Xiaoyong Zhu <xiaoyzhu@outlook.com>