### PR TITLE
Upgrade `actions/checkout` version from `v2` to `v3` to clean up node 12 deprecated warnings

### DIFF
--- a/.github/workflows/document-scan.yml
+++ b/.github/workflows/document-scan.yml
@@ -8,7 +8,8 @@ jobs:
   check-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -21,7 +21,8 @@ jobs:
   gradle_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up JDK 8

--- a/.github/workflows/publish-to-azure-storage.yml
+++ b/.github/workflows/publish-to-azure-storage.yml
@@ -10,17 +10,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
 
-    # Setting up JDK 8, this is required to build Feathr
+      # Setting up JDK 8, this is required to build Feathr
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
           java-version: "8"
           distribution: "temurin"
 
-    # Publish Released Fat Jar to Blob Storage 
+      # Publish Released Fat Jar to Blob Storage 
       - name: Gradle build
         run: |  
           ./gradlew build

--- a/.github/workflows/publish-to-dockerhub.yml
+++ b/.github/workflows/publish-to-dockerhub.yml
@@ -74,7 +74,7 @@ jobs:
   # Trigger Azure Web App webhooks to pull the latest nightly image
   deploy:
     runs-on: ubuntu-latest
-    needs: build_and_push_image_to_registry
+    needs: build_and_push_feathr_registry_image
 
     steps:
       - name: Deploy to Azure Web App feathr-registry-purview

--- a/.github/workflows/publish-to-maven.yml
+++ b/.github/workflows/publish-to-maven.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
 
-    # Setting up JDK 8, this is required to build Feathr
+      # Setting up JDK 8, this is required to build Feathr
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
@@ -25,9 +25,9 @@ jobs:
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: ORG_GRADLE_PROJECT_signingInMemoryKeyPassword
 
-    # CI release command defaults to publishSigned
-    # Sonatype release command defaults to sonaTypeBundleRelease
-    # Changing env names as documented here - https://vanniktech.github.io/gradle-maven-publish-plugin/central/#secrets
+      # CI release command defaults to publishSigned
+      # Sonatype release command defaults to sonaTypeBundleRelease
+      # Changing env names as documented here - https://vanniktech.github.io/gradle-maven-publish-plugin/central/#secrets
       - name: Gradle Build and Publish to Maven central
         run: |
           ./gradlew publish

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -29,7 +29,7 @@ jobs:
           twine check --strict dist/*
       
       
-   # Build and upload to PyPI
+      # Build and upload to PyPI
       - name: "Builds and uploads to PyPI"
         run: |
           cd ./feathr_project

--- a/.github/workflows/pull_request_push_test.yml
+++ b/.github/workflows/pull_request_push_test.yml
@@ -39,7 +39,8 @@ jobs:
       # output2 - if changes for a PR contain registry files
       output2: ${{ steps.filter_registry.outputs.registry }}
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v3
     - uses: dorny/paths-filter@v2
       id: filter_src
       with:
@@ -66,7 +67,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe to test'))
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up JDK 8
@@ -134,7 +136,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe to test'))
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up JDK 8
@@ -202,7 +205,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe to test'))
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up JDK 8
@@ -260,7 +264,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'registry test'))
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up JDK 8

--- a/.github/workflows/ui-check.yml
+++ b/.github/workflows/ui-check.yml
@@ -17,7 +17,8 @@ jobs:
     name: eslint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
       - uses: reviewdog/action-eslint@v1
         with:
           eslint_flags: "src/"
@@ -28,7 +29,8 @@ jobs:
     name: prettier_code_formatter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2 # Check out the repository first.
+      - name: Checkout
+        uses: actions/checkout@v3
       - uses: actionsx/prettier@v2
         with:
           # prettier CLI arguments.


### PR DESCRIPTION
- Upgrade action checkout version from `v2` to `v3`

## Description
<!--
Hey! Thank you for the contribution! Please go through https://github.com/feathr-ai/feathr/blob/main/docs/dev_guide/pull_request_guideline.md for more information.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Upgrade `actions/checkout` version from `v2` to `v3` to clean up node 12 deprecated warnings

## How was this PR tested?
<!--
Describe what testings you have done. If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide UI screenshot, the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
No