### PR TITLE
Fix skipping features when derived feature contains a swa feature

### DIFF
--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/config/sources/FeatureGroupsUpdater.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/config/sources/FeatureGroupsUpdater.scala
@@ -111,17 +111,18 @@ private[offline] class FeatureGroupsUpdater {
   }
 
   /**
-   * Update the feature groups (for Feature join) based on feature missing features. Few anchored features can be missing if the feature data
+   * Update the feature groups (for Feature join) based on feature missing features. Few anchored/SWA features can be missing if the feature data
    * is not present. Remove those anchored features, and also the corresponding derived feature which are dependent on it.
    *
-   * @param featureGroups
-   * @param allStageFeatures
-   * @param keyTaggedFeatures
-   * @return
+   * @param featureGroups Original feature groups
+   * @param allAnchoredFeaturesWithData all anchored features which were not skipped because of missing data
+   * @param skippedSwaFeatures skipped SWA features due to missing data issue.
+   * @param keyTaggedFeatures List of all key tagged features
+   * @return  Updated feature groups and updated list of joining features
    */
   def removeMissingFeatures(featureGroups: FeatureGroups, allAnchoredFeaturesWithData: Seq[String], skippedSwaFeatures: Seq[String],
     keyTaggedFeatures: Seq[JoiningFeatureParams]): (FeatureGroups, Seq[JoiningFeatureParams]) = {
-
+    // Filter out all the window agg features that were skipped.
     val updatedWindowAggFeatures = featureGroups.allWindowAggFeatures.filter(windowAggFeature => !skippedSwaFeatures.contains(windowAggFeature._1))
     // We need to add the window agg features to it as they are also considered anchored features.
     val updatedAnchoredFeatures = featureGroups.allAnchoredFeatures.filter(featureRow =>

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/config/sources/FeatureGroupsUpdater.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/config/sources/FeatureGroupsUpdater.scala
@@ -110,45 +110,6 @@ private[offline] class FeatureGroupsUpdater {
     (updatedFeatureGroups, updatedKeyTaggedFeatures)
   }
 
-
-  /**
-   * Update the feature groups (for Feature join) based on feature missing features after SWA features are skipped.
-   *
-   * @param featureGroups
-   * @param allStageFeatures
-   * @param keyTaggedFeatures
-   * @return
-   */
-  def removeMissingFeaturesAfterSwa(featureGroups: FeatureGroups, allSkippedSWAFeatures: Seq[String],
-    keyTaggedFeatures: Seq[JoiningFeatureParams]): (FeatureGroups, Seq[JoiningFeatureParams]) = {
-
-    val updatedSeqJoinFeature = featureGroups.allSeqJoinFeatures.filter(seqJoinFeature => {
-      // Find the constituent anchored features for every derived feature
-      val allAnchoredFeaturesInDerived = seqJoinFeature._2.consumedFeatureNames.map(_.getFeatureName)
-      val containsFeature: Seq[Boolean] = allAnchoredFeaturesInDerived.map(feature => allSkippedSWAFeatures.contains(feature))
-      !containsFeature.contains(false)
-    })
-
-    // Iterate over the derived features and remove the derived features which contains these anchored features.
-    val updatedDerivedFeatures = featureGroups.allDerivedFeatures.filter(derivedFeature => {
-      // Find the constituent anchored features for every derived feature
-      val allAnchoredFeaturesInDerived = derivedFeature._2.consumedFeatureNames.map(_.getFeatureName)
-      val containsFeature: Seq[Boolean] = allAnchoredFeaturesInDerived.map(feature => allSkippedSWAFeatures.contains(feature)
-        || featureGroups.allDerivedFeatures.contains(feature))
-      containsFeature.contains(false)
-    }) ++ updatedSeqJoinFeature
-
-    log.warn(s"Removed the following features:- " +
-      s"${featureGroups.allDerivedFeatures.keySet.diff(updatedDerivedFeatures.keySet)}," +
-      s" ${featureGroups.allSeqJoinFeatures.keySet.diff(updatedSeqJoinFeature.keySet)}")
-    val updatedFeatureGroups = FeatureGroups(featureGroups.allAnchoredFeatures, updatedDerivedFeatures, featureGroups.allWindowAggFeatures,
-      featureGroups.allPassthroughFeatures, updatedSeqJoinFeature)
-    val updatedKeyTaggedFeatures = keyTaggedFeatures.filter(feature => featureGroups.allAnchoredFeatures.contains(feature.featureName)
-      || updatedDerivedFeatures.contains(feature.featureName) || featureGroups.allWindowAggFeatures.contains(feature.featureName)
-      || featureGroups.allPassthroughFeatures.contains(feature.featureName) || updatedSeqJoinFeature.contains(feature.featureName))
-    (updatedFeatureGroups, updatedKeyTaggedFeatures)
-  }
-
   /**
    * Update the feature groups (for Feature join) based on feature missing features. Few anchored features can be missing if the feature data
    * is not present. Remove those anchored features, and also the corresponding derived feature which are dependent on it.

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/join/DataFrameFeatureJoiner.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/join/DataFrameFeatureJoiner.scala
@@ -203,6 +203,7 @@ private[offline] class DataFrameFeatureJoiner(logicalPlan: MultiStageJoinPlan, d
     val (FeatureDataFrame(withWindowAggFeatureDF, inferredSWAFeatureTypes), skippedFeatures) =
       joinSWAFeatures(ss, obsToJoinWithFeatures, joinConfig, featureGroups, failOnMissingPartition, bloomFilters, swaObsTime, swaHandler)
 
+    // Update the feature groups based on the missing features
     val (updatedFeatureGroups, updatedLogicalPlan) = if (shouldSkipFeature) {
       val (newFeatureGroups, newKeyTaggedFeatures) = FeatureGroupsUpdater().removeMissingFeatures(featureGroups,
         updatedSourceAccessorMap.keySet.flatMap(featureAnchorWithSource => featureAnchorWithSource.featureAnchor.features).toSeq, skippedFeatures, keyTaggedFeatures)
@@ -314,7 +315,7 @@ private[offline] class DataFrameFeatureJoiner(logicalPlan: MultiStageJoinPlan, d
    * @param failOnMissingPartition flag to indicate if the join job should fail if a missing date partition is found.
    * @param bloomFilters bloomfilters, map string key tag ids to bloomfilter
    * @param swaObsTime observation start and end time for sliding window aggregation, if not None, will try to infer
-   * @return observation data joined with sliding window aggregation features
+   * @return observation data joined with sliding window aggregation features and the list of skipped features
    */
   def joinSWAFeatures(
       ss: SparkSession,

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/join/DataFrameFeatureJoiner.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/join/DataFrameFeatureJoiner.scala
@@ -203,7 +203,8 @@ private[offline] class DataFrameFeatureJoiner(logicalPlan: MultiStageJoinPlan, d
     val (FeatureDataFrame(withWindowAggFeatureDF, inferredSWAFeatureTypes), skippedFeatures) =
       joinSWAFeatures(ss, obsToJoinWithFeatures, joinConfig, featureGroups, failOnMissingPartition, bloomFilters, swaObsTime, swaHandler)
 
-    // Update the feature groups based on the missing features
+    // Update the feature groups based on the missing features. Certain SWA features can be skipped because of missing data issue, we need to skip
+    // the corresponding derived, seq join features which could depend on this SWA feature.
     val (updatedFeatureGroups, updatedLogicalPlan) = if (shouldSkipFeature) {
       val (newFeatureGroups, newKeyTaggedFeatures) = FeatureGroupsUpdater().removeMissingFeatures(featureGroups,
         updatedSourceAccessorMap.keySet.flatMap(featureAnchorWithSource => featureAnchorWithSource.featureAnchor.features).toSeq, skippedFeatures, keyTaggedFeatures)

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/swa/SlidingWindowAggregationJoiner.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/swa/SlidingWindowAggregationJoiner.scala
@@ -70,6 +70,7 @@ private[offline] class SlidingWindowAggregationJoiner(
    *         it can be converted to a pair RDD of (observation data record, feature record),
    *         each feature resides in a column and it is named using DataFrameColName.genFeatureColumnName(..)
    *         2) inferred feature types
+   *         Also, returns the list of skipped features
    */
   def joinWindowAggFeaturesAsDF(
       ss: SparkSession,

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/swa/SlidingWindowAggregationJoiner.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/swa/SlidingWindowAggregationJoiner.scala
@@ -81,7 +81,7 @@ private[offline] class SlidingWindowAggregationJoiner(
       bloomFilters: Option[Map[Seq[Int], BloomFilter]],
       swaObsTimeOpt: Option[DateTimeInterval],
       failOnMissingPartition: Boolean,
-      swaHandler: Option[SWAHandler]): FeatureDataFrame = {
+      swaHandler: Option[SWAHandler]): (FeatureDataFrame, Seq[String]) = {
     val joinConfigSettings = joinConfig.settings
     // extract time window settings
     if (joinConfigSettings.isEmpty) {
@@ -292,7 +292,7 @@ private[offline] class SlidingWindowAggregationJoiner(
           }
         }
     }})
-    offline.FeatureDataFrame(contextDF, allInferredFeatureTypes.toMap)
+    (offline.FeatureDataFrame(contextDF, allInferredFeatureTypes.toMap), notJoinedFeatures.toSeq)
   }
 
   /**

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/SlidingWindowAggIntegTest.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/SlidingWindowAggIntegTest.scala
@@ -571,7 +571,7 @@ class SlidingWindowAggIntegTest extends FeathrIntegTest {
         |features: [
         |  {
         |    key: [x],
-        |    featureList: ["simplePageViewCount", "simpleFeature"]
+        |    featureList: ["simplePageViewCount", "simpleFeature", "derived_simpleFeature"]
         |  }
         |]
       """.stripMargin
@@ -621,6 +621,9 @@ class SlidingWindowAggIntegTest extends FeathrIntegTest {
         |     }
         |    }
         |  }
+        |}
+        |derivations: {
+        | derived_simpleFeature: simpleFeature
         |}
       """.stripMargin
     val res = runLocalFeatureJoinForTest(joinConfigAsString, featureDefAsString, observationDataPath = "slidingWindowAgg/localAnchorTestObsData.avro.json").data

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.0.2-rc2
+version=1.0.2-rc3
 SONATYPE_AUTOMATIC_RELEASE=true
 POM_ARTIFACT_ID=feathr_2.12


### PR DESCRIPTION
Derived features can be dependent on SWA features. If the SWA feature is skipped because of data missing issue, the corresponding derived features should also be skipped.
Before this change, the derived features were getting skipped only if the constituent anchored/derived features were skipped.