### PR TITLE
Add Feathr chat bot in the notebook(Experimental, powered by ChatGPT)

### DIFF
--- a/docs/samples/local_quickstart_notebook.ipynb
+++ b/docs/samples/local_quickstart_notebook.ipynb
@@ -904,7 +904,7 @@
    },
    "source": [
     "## 7. Feature Registration\n",
-    "Lastly, we can also register the features and share them across teams:"
+    "We can also register the features and share them across teams:"
    ]
   },
   {
@@ -946,6 +946,91 @@
    "source": [
     "from IPython.display import IFrame\n",
     "IFrame(\"http://localhost:8081/projects\", 900,500)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Chat with Feathr (Experimental, powered by ChatGPT)\n",
+    "First, let's setup the API_KEY for ChatGPT. You can find your api key at https://platform.openai.com/account/api-keys."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ['CHATGPT_API_KEY'] = 'YOUR_CHAT_GPT_API_KEY'\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load 'feathr' chat magic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%reload_ext feathr.chat"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Start chat!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%feathr \"What are the available features\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%feathr \"What are the available data sources\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%feathr \"Create a feature tax_rate_demical = tax_rate/100\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%feathr \"Join feature tax_rate_demical with my observation data in point-in-time manner\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%feathr \"Materialize my feature tax_rate_demical\""
    ]
   },
   {

--- a/feathr_project/feathr/chat/__init__.py
+++ b/feathr_project/feathr/chat/__init__.py
@@ -1,0 +1,39 @@
+
+from IPython.core.magic import Magics, line_magic, magics_class
+
+from feathr.chat.feathr_chat import FeathrChat
+from feathr.chat.prompt_generator import PromptGenerator
+from IPython import get_ipython
+
+chatBot = FeathrChat()
+dsl_learned = False
+@magics_class
+class FeathrMagic(Magics):
+
+    @line_magic
+    def feathr(self, question):
+        scope = get_ipython().get_local_scope(stack_depth=2) 
+        client = scope.get('client')
+        global dsl_learned
+        if client:
+            prompt_generator = PromptGenerator(client)
+            if not dsl_learned:
+                ask_to_teach = "I am going to teach you a DSL, could you learn it?"
+                chatBot.ask_llm_in_notebook(ask_to_teach)
+                dsl = '\n Feathr DSL: \n' + prompt_generator.get_feathr_dsl_prompts()
+                chatBot.ask_llm_in_notebook(dsl)
+                
+                ask_to_teach = "Do you want to see the full source code for the APIs?"
+                chatBot.ask_llm_in_notebook(ask_to_teach)
+                dsl = '\n Feathr DSL: \n' + prompt_generator.get_full_dsl_source_code()
+                chatBot.ask_llm_in_notebook(dsl)
+                
+                dsl_learned = True
+            question_with_prompt = prompt_generator.process_question(question)
+            chatBot.ask_llm_in_notebook(question_with_prompt)
+        else:
+            print("'client' is not defined in the notebook. Please create a FeathrClient instance named as 'client' before using Feathr chat. e.g. client = FeathrClient('/path/to/your/workspace') ")
+
+
+def load_ipython_extension(ipython):
+    ipython.register_magics(FeathrMagic)

--- a/feathr_project/feathr/chat/feathr_chat.py
+++ b/feathr_project/feathr/chat/feathr_chat.py
@@ -1,0 +1,36 @@
+import os
+from typing import Optional
+from revChatGPT.V3 import Chatbot
+from feathr.chat.notebook_utils import *
+
+class FeathrChat(object):
+    def __init__(self):
+        key = self.get_api_key()
+        self.chat_bot = None
+        self.feathr_client = None
+        if key:
+            self.chat_bot = Chatbot(key)
+
+    def get_api_key(self):
+        return os.getenv("CHATGPT_API_KEY", None)
+
+    def ask_llm_in_notebook(self, question_with_prompt: str):
+        """Ask LLM model a question within the notebook"""
+        if not self.chat_bot:
+            key = self.get_api_key()
+            if not key:
+                raise RuntimeError("Please set environment variable CHATGPT_API_KEY before using Feathr Chat. You can get your API key for ChatGPT at https://platform.openai.com/account/api-keys. For example, run: os.environ['CHATGPT_API_KEY'] = 'your api key' and retry.")
+            self.chat_bot = Chatbot(key)
+
+        content = self.chat_bot.ask(question_with_prompt)
+        if "```" in content and self.is_a_code_gen_question(question_with_prompt):
+            # for debugging
+            # res = content
+            # print(re.sub(r"```.*```", "", res, flags=re.DOTALL))
+            code = extract_code_from_string(content)
+            create_new_cell(code)
+        else:
+            print(content)
+    
+    def is_a_code_gen_question(self, question_with_prompt):
+        return "explain" not in question_with_prompt.lower() and "what" not in question_with_prompt.lower()

--- a/feathr_project/feathr/chat/notebook_utils.py
+++ b/feathr_project/feathr/chat/notebook_utils.py
@@ -1,0 +1,23 @@
+from IPython.core.getipython import get_ipython
+import re
+
+def create_new_cell(contents):
+    shell = get_ipython()
+    payload = dict(
+        source='set_next_input',
+        text=contents,
+        replace=False,
+    )
+    shell.payload_manager.write_payload(payload, single=False)
+    
+
+def extract_code_from_string(input_str, lang='python'):
+    """Extract the code block for a given language"""
+    pattern = fr'```({lang}|\s*)\n(.*?)\n```'
+    # Use the re.findall() function to extract the code block
+    match = re.search(pattern, input_str, re.DOTALL)
+    # Check if any code block was found
+    if match:
+        return match.group(2)
+    else:
+        return ""

--- a/feathr_project/feathr/chat/prompt_generator.py
+++ b/feathr_project/feathr/chat/prompt_generator.py
@@ -1,0 +1,179 @@
+from feathr.client import FeathrClient
+import os
+
+from feathr.chat.source_code_utils import read_source_code_compact
+
+class PromptGenerator(object):
+    def __init__(self, client: FeathrClient) -> None:
+        self.client = client
+        self.module_path = os.path.dirname(os.path.abspath(__file__))
+        self.dsl_learned = False
+
+    def get_feathr_dsl_prompts(self):
+        prompts = f"""
+        Feathr DSL can be used to create features in these steps:
+        1) Import required classes, for example:
+        from feathr import (
+            FeathrClient,
+            BOOLEAN, FLOAT, INT32, ValueType,
+            Feature, DerivedFeature, FeatureAnchor,
+            INPUT_CONTEXT, HdfsSource,
+            WindowAggTransformation,
+            TypedKey
+        )
+
+        2) Define a source processing UDF my_source_udf_name. Put necessary imports within the function body. For example:
+        def my_source_udf_name(df: DataFrame) -> DataFrame:
+            df.withColumn(feature_field_name, feature_expression)
+            
+        3) Define a source, for example:
+        batch_source = HdfsSource(
+            name=source_name,
+            path=source_path,
+            preprocessing=source_processing_func_name,
+        )
+        4) Define a key, for example:
+        user_id = TypedKey(
+            key_column=key_column_in_source_data,
+            key_column_type=ValueType.INT32,
+            description=key_column_description",
+            full_name=project_name_and_key_column_name,
+        )
+        5) Define a feature, for example:
+        feature_object = Feature(
+            name=feature_name,
+            key=key_name
+            feature_type=FLOAT,
+            transform=feature_field_name,
+        ) 
+
+        feature_list = [ 
+            feature_object, 
+        ]
+
+        6) Define a feature anchor, for example:
+        feature_anchor = FeatureAnchor(
+            name=anchor_name, 
+            source=batch_source,
+            features=feature_list
+        )
+        7) Use existing client to build and register features. For example,
+           Note that you should assume the client object exist and do not need to create a client.
+            client.build_features(
+                anchor_list=[feature_anchor],
+                derived_feature_list=[],
+            )
+            client.register_features()
+        """
+        prompts += self.get_materialization_prompts()
+        prompts += self.get_test_prompts()
+        prompts += self.get_join_dsl_prompts() 
+        prompts += self.get_features_prompts()
+        return prompts
+
+    def get_full_dsl_source_code(self):
+        prompts = ""
+        client_source_code = '\n Feathr client API: \n' + read_source_code_compact(self.module_path, self.module_path + '/../client.py')
+        prompts += client_source_code
+       
+        definition_source_code = read_source_code_compact(self.module_path, self.module_path + '/../definition')
+        prompts += f"""The full classes for the Feathr DSL is here: {definition_source_code}"""
+        return prompts
+
+    def get_join_dsl_prompts(self):
+        return """
+        Feathr DSL syntax can be used to join features with observation data in these steps:
+        1) Define a key
+        user_id = TypedKey(
+            key_column=key_column_in_observation_data,
+            key_column_type=ValueType.INT32,
+            description=key_column_description",
+            full_name=project_name_and_key_column_name,
+        )
+        2) Define a feature query
+        feature_query = FeatureQuery(
+            feature_list=[feature_name],
+            key=feauture_key,
+        )
+        3) Define a observation join settings
+        settings = ObservationSettings(
+            observation_path=user_observation_source_path,
+            event_timestamp_column= timestamp_column_name # e.g. "event_timestamp",
+            timestamp_format= timestamp_format # e.g. "yyyy-MM-dd"
+        )
+        4) Call the feature join API with the observation join setting, feature query, and the output path.
+        Assume the client is created already. Do not create it here.
+        client.get_offline_features(
+            observation_settings=settings,
+            feature_query=[user_feature_query],
+            output_path=user_profile_source_path.rpartition("/")[0] + f"/product_recommendation_features2.avro",
+        )
+        5) Wait for job to finish to show the result
+        client.wait_job_to_finish(timeout_sec=5000)
+        
+        6) Get the resulting dataframe by calling get_result_df and pass the client as parameter. 
+        res_df = get_result_df(client)
+        res_df.head()
+        
+
+        """
+    def get_test_prompts(self):
+        return f"""
+            The API to test a feature anchor is:
+                FeathrTest.run(feature_anchor, mock_df, start_time, end_time).
+            It will return a dataframe, while start_time and end_time is optional.
+            
+            The API to test a derived feature is:
+                FeathrTest.run(derived_feature, [[keys]]) which takes a 2-d array as parameter and returns a list of feature value.
+
+        """
+
+    def get_materialization_prompts(self):
+        return f"""
+            class RedisSink:
+                def __init__(self, table_name="user_features")
+                
+            The API to materialize a feature anchor is:
+                feature_names = ["feature_A", "feature_B"]
+                redisSink = RedisSink(
+                    table_name="user_features"
+                )
+                settings = MaterializationSettings(
+                    name="settings",
+                    sinks=[redisSink],
+                    feature_names=feature_names,
+                )
+
+                client.materialize_features(settings=settings, allow_materialize_non_agg_feature=True)
+                client.wait_job_to_finish(timeout_sec=5000)
+        """
+
+    def get_features_prompts(self):
+        return f"""
+            The API to get the previously joined dataset is:
+                Get the joined dataframe by calling get_result_df and pass the client as parameter
+                res_df = get_result_df(client)
+                res_df.head()
+        
+            The API to get materialized feature values from online storage is:
+                fv = client.multi_get_online_feature_values(
+                "user_features", [keys], [feature_names]
+                print (fv)
+            )
+        """
+        
+    def get_metadata_prompts(self):
+        # Get from registry
+        # TODO return metadata from registry
+        #features = self.client.registry.list_registered_features(self.client.project_name)
+        #return f""" registered features are {features}	"""
+        return ""
+ 
+    def process_question(self, question: str):
+        prompts = " My question is: " + question + ". \n Requirement: Please use the provided Feathr DSL if you're able to, do not use API or concept from other feature engineering related solutions. You can assume an instance of FeathrClient is already created and named as 'client'.  If your anwser has code, combine all your code in a block."
+        prompts += "\n Context Information:\n"
+        prompts += self.get_metadata_prompts()  
+        if "train" in question.lower():
+            prompts = prompts + ". Do not use event timestamp related columns in model training."
+        return prompts
+        

--- a/feathr_project/feathr/chat/source_code_utils.py
+++ b/feathr_project/feathr/chat/source_code_utils.py
@@ -1,0 +1,48 @@
+import ast
+import os
+import re
+
+def read_source_code_compact(module_path, source_file_or_dir_path):
+    # Get a list of all Python files in the specified directory and its subdirectories
+    # If it is a file, directly read the file.
+    python_files = []
+    if source_file_or_dir_path.endswith('.py'):
+            python_files.append(source_file_or_dir_path)
+    for root, dirs, files in os.walk(source_file_or_dir_path):
+        for file in files:
+            if file.endswith('.py'):
+                python_files.append(os.path.join(root, file))
+
+    # Concatenate the contents of all Python files into a single string
+    concatenated_contents = ''
+    for file_path in python_files:
+        with open(file_path, 'r') as f:
+            # Parse the file into an abstract syntax tree (AST)
+            tree = ast.parse(f.read())
+
+            # Traverse the AST and remove function implementations
+            for node in ast.walk(tree):
+                remove_function_implementations(node)
+
+            # Convert the AST back to Python code
+            code = ast.unparse(tree)
+            relative_path = os.path.relpath(file_path, module_path)
+            concatenated_contents += '\n' + 'In file: ' + relative_path + '\n' + remove_comments(code)
+
+    return concatenated_contents
+
+def remove_comments(source):
+    # Remove block comments
+    source = re.sub(r'""".*?"""', '', source, flags=re.DOTALL)
+    # Remove line comments
+    source = re.sub(r'#.*?\n', '', source)
+    # Remove empty lines
+    source = re.sub(r'^\s*\n', '', source, flags=re.MULTILINE)
+    return source
+
+# Define a function to remove the function implementations
+def remove_function_implementations(node):
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        # Replace the function body with a single 'pass' statement
+        node.body = [ast.Pass()]
+    ast.fix_missing_locations(node)

--- a/feathr_project/feathr/version.py
+++ b/feathr_project/feathr/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 def get_version():
     return __version__

--- a/feathr_project/feathr/version.py
+++ b/feathr_project/feathr/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.1"
+__version__ = "1.0.0"
 
 def get_version():
     return __version__

--- a/feathr_project/setup.py
+++ b/feathr_project/setup.py
@@ -41,7 +41,7 @@ extras_require=dict(
         "papermill>=2.1.2,<3",      # to test run notebooks
         "scrapbook>=0.5.0,<1.0.0",  # to scrap notebook outputs
         "scikit-learn",             # for notebook examples
-        "plotly",                   # for plotting
+        "plotly"                   # for plotting
     ],
 )
 extras_require["all"] = list(set(sum([*extras_require.values()], [])))
@@ -98,7 +98,9 @@ setup(
         # it brings a different version of msrest(0.7.0) which is incompatible with azure-core==1.22.1. Hence we need to pin it.
         # See this for more details: https://github.com/Azure/azure-sdk-for-python/issues/24765
         "msrest<=0.6.21",
-        "typing_extensions>=4.2.0"
+        "typing_extensions>=4.2.0",
+        "ipython",                  # for chat in notebook
+        "revChatGPT" 
     ],
     tests_require=[  # TODO: This has been depricated
         "pytest",


### PR DESCRIPTION
## Description
Add Feathr chat bot in the notebook(Experimental, powered by ChatGPT)

## Does this PR introduce any user-facing changes?
Yes.
Users can now chat with Feathr. It will generate code written in Feathr DSL and automatically extract them into a new runnable cell. This is an experimental feature added to help improve user productivity by chatting directly with Feathr in natural language.

NOTE that the generated code may not produce correct result or even not runnable in the first place. You can modify the auto-generated code, as well as add more context/prompt in the chat to improve result. Different versions of ChatGPT may perform differently on the same input prompt.

The usage is simple, in the notebook:
1. Set os.environ['CHATGPT_API_KEY']. The API KEY can be obtained from https://platform.openai.com/account/api-keys.
2. Load 'feathr' chat magic" by running  "%reload_ext feathr.chat"
3. Use %feathr "your question" to start chat with Feathr

For example, try:
%feathr "What are the available features"
%feathr  "What are the available data sources"
%feathr "Create a feature tax_rate_demical = tax_rate/100"
%feathr  "Join feature tax_rate_demical with my observation data in point-in-time manner"
%feathr "Materialize my feature tax_rate_demical"
%feathr "Train a model to predict user rating on product"

## How was this PR tested?
Run notebook local_quickstart_notebook.ipynb 