### PR TITLE
Add default column for missing features

### DIFF
--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/client/FeathrClient.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/client/FeathrClient.scala
@@ -1,7 +1,7 @@
 package com.linkedin.feathr.offline.client
 
 import com.linkedin.feathr.common.exception._
-import com.linkedin.feathr.common.{FeatureInfo, Header, InternalApi, JoiningFeatureParams, RichConfig, TaggedFeatureName}
+import com.linkedin.feathr.common.{FeatureInfo, FeatureTypeConfig, Header, InternalApi, JoiningFeatureParams, RichConfig, TaggedFeatureName}
 import com.linkedin.feathr.offline.config.sources.FeatureGroupsUpdater
 import com.linkedin.feathr.offline.config.{FeathrConfig, FeathrConfigLoader, FeatureGroupsGenerator, FeatureJoinConfig}
 import com.linkedin.feathr.offline.generation.{DataFrameFeatureGenerator, FeatureGenKeyTagAnalyzer, StreamingFeatureGenerator}
@@ -12,8 +12,10 @@ import com.linkedin.feathr.offline.mvel.plugins.FeathrExpressionExecutionContext
 import com.linkedin.feathr.offline.source.DataSource
 import com.linkedin.feathr.offline.source.accessor.DataPathHandler
 import com.linkedin.feathr.offline.swa.SWAHandler
+import com.linkedin.feathr.offline.transformation.DataFrameDefaultValueSubstituter.substituteDefaults
 import com.linkedin.feathr.offline.util._
 import org.apache.logging.log4j.LogManager
+import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
@@ -310,6 +312,8 @@ class FeathrClient private[offline] (sparkSession: SparkSession, featureGroups: 
 
     var logicalPlan = logicalPlanner.getLogicalPlan(updatedFeatureGroups, keyTaggedFeatures)
     val shouldSkipFeature = FeathrUtils.getFeathrJobParam(sparkSession.sparkContext.getConf, FeathrUtils.SKIP_MISSING_FEATURE).toBoolean
+    val shouldAddDefault = FeathrUtils.getFeathrJobParam(sparkSession.sparkContext.getConf, FeathrUtils.ADD_DEFAULT_COL_FOR_MISSING_DATA).toBoolean
+    var leftRenamed = left
     val featureToPathsMap = (for {
       requiredFeature <- logicalPlan.allRequiredFeatures
       featureAnchorWithSource <- allAnchoredFeatures.get(requiredFeature.getFeatureName)
@@ -323,6 +327,8 @@ class FeathrClient private[offline] (sparkSession: SparkSession, featureGroups: 
             val featureGroupsWithoutInvalidFeatures = FeatureGroupsUpdater()
               .getUpdatedFeatureGroupsWithoutInvalidPaths(featureToPathsMap, updatedFeatureGroups, featurePathsTest._2)
             logicalPlanner.getLogicalPlan(featureGroupsWithoutInvalidFeatures, keyTaggedFeatures)
+          } else if (shouldAddDefault) {
+            // dont throw error if this flag is set, the missing data will be handled at a later step.
           } else {
             throw new FeathrInputDataException(
               ErrorLabel.FEATHR_USER_ERROR,
@@ -358,7 +364,6 @@ class FeathrClient private[offline] (sparkSession: SparkSession, featureGroups: 
       val renameFeatures = conflictsAutoCorrectionSetting.get.renameFeatureList
       val suffix = conflictsAutoCorrectionSetting.get.suffix
       log.warn(s"Found conflicted field names: ${conflictFeatureNames}. Will auto correct them by applying suffix: ${suffix}")
-      var leftRenamed = left
       conflictFeatureNames.foreach(name => {
         leftRenamed = leftRenamed.withColumnRenamed(name, name+'_'+suffix)
       })
@@ -369,7 +374,8 @@ class FeathrClient private[offline] (sparkSession: SparkSession, featureGroups: 
             s"Failed to apply auto correction to solve conflicts. Still got conflicts after applying provided suffix ${suffix} for fields: " +
               s"${conflictFeatureNames}. Please provide another suffix or solve conflicts manually.")
       }
-      val (df, header) = joiner.joinFeaturesAsDF(sparkSession, joinConfig, updatedFeatureGroups, keyTaggedFeatures, leftRenamed, rowBloomFilterThreshold)
+      val (df, header) = joiner.joinFeaturesAsDF(sparkSession, joinConfig, updatedFeatureGroups, keyTaggedFeatures, leftRenamed,
+        rowBloomFilterThreshold)
       if(renameFeatures) {
         log.warn(s"Suffix :${suffix} is applied into feature names: ${conflictFeatureNames} to avoid conflicts in outputs")
         renameFeatureNames(df, header, conflictFeatureNames, suffix)

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/join/workflow/AnchoredFeatureJoinStep.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/join/workflow/AnchoredFeatureJoinStep.scala
@@ -86,6 +86,7 @@ private[offline] class AnchoredFeatureJoinStep(
 
     // We want to duplicate this column with the correct feathr supported feature name which is required for further processing.
     // For example, if feature name is abc and the corresponding key is x, the column name would be __feathr_feature_abc_x.
+    // This column will be dropped after all the joins are done.
     missingFeatures.keys.foldLeft(dataframeWithDefaults) { (dataframeWithDefaults, featureName) =>
       val keyTags = logicalPlan.joinStages.filter(kv => kv._2.contains(featureName)).head._1
       val keyStr = keyTags.map(logicalPlan.keyTagIntsToStrings).toList

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/join/workflow/AnchoredFeatureJoinStep.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/join/workflow/AnchoredFeatureJoinStep.scala
@@ -106,13 +106,15 @@ private[offline] class AnchoredFeatureJoinStep(
     val AnchorJoinStepInput(observationDF, anchorDFMap) = input
     val shouldAddDefault = FeathrUtils.getFeathrJobParam(ctx.sparkSession.sparkContext.getConf,
       FeathrUtils.ADD_DEFAULT_COL_FOR_MISSING_DATA).toBoolean
-    val missingFeatures = features.map(x => x.getFeatureName).filter(x => {
-      val containsFeature :Seq[Boolean] = anchorDFMap.map(y => y._1.selectedFeatures.contains(x)).toSeq
-      containsFeature.contains(false)
-    })
-    val missingAnchoredFeatures = ctx.featureGroups.allAnchoredFeatures.filter(featureName => missingFeatures.contains(featureName._1))
-    val withMissingFeaturesSubstituted = if (shouldAddDefault) substituteDefaultsForDataMissingFeatures(ctx.sparkSession, observationDF, ctx.logicalPlan,
-      missingAnchoredFeatures) else observationDF
+    val withMissingFeaturesSubstituted = if (shouldAddDefault) {
+        val missingFeatures = features.map(x => x.getFeatureName).filter(x => {
+        val containsFeature: Seq[Boolean] = anchorDFMap.map(y => y._1.selectedFeatures.contains(x)).toSeq
+        containsFeature.contains(false)
+      })
+      val missingAnchoredFeatures = ctx.featureGroups.allAnchoredFeatures.filter(featureName => missingFeatures.contains(featureName._1))
+      substituteDefaultsForDataMissingFeatures(ctx.sparkSession, observationDF, ctx.logicalPlan,
+        missingAnchoredFeatures)
+    }else observationDF
 
     val allAnchoredFeatures: Map[String, FeatureAnchorWithSource] = ctx.featureGroups.allAnchoredFeatures
     val joinStages = ctx.logicalPlan.joinStages

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/transformation/AnchorToDataSourceMapper.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/transformation/AnchorToDataSourceMapper.scala
@@ -37,6 +37,8 @@ private[offline] class AnchorToDataSourceMapper(dataPathHandlers: List[DataPathH
       requiredFeatureAnchors: Seq[FeatureAnchorWithSource],
       failOnMissingPartition: Boolean): Map[FeatureAnchorWithSource, Option[DataSourceAccessor]] = {
     val shouldSkipFeature = FeathrUtils.getFeathrJobParam(ss.sparkContext.getConf, FeathrUtils.SKIP_MISSING_FEATURE).toBoolean
+    val shouldAddDefaultCol = FeathrUtils.getFeathrJobParam(ss.sparkContext.getConf, FeathrUtils.ADD_DEFAULT_COL_FOR_MISSING_DATA).toBoolean
+
     // get a Map from each source to a list of all anchors based on this source
     val sourceToAnchor = requiredFeatureAnchors
       .map(anchor => (anchor.source, anchor))
@@ -74,7 +76,7 @@ private[offline] class AnchorToDataSourceMapper(dataPathHandlers: List[DataPathH
 
           // If it is a nonTime based source, we will load the dataframe at runtime, however this is too late to decide if the
           // feature should be skipped. So, we will try to take the first row here, and see if it succeeds.
-          if (dataSource.isInstanceOf[NonTimeBasedDataSourceAccessor] && shouldSkipFeature) {
+          if (dataSource.isInstanceOf[NonTimeBasedDataSourceAccessor] && (shouldSkipFeature || shouldAddDefaultCol)) {
             if (dataSource.get().take(1).isEmpty) None else {
               Some(dataSource)
             }
@@ -82,7 +84,7 @@ private[offline] class AnchorToDataSourceMapper(dataPathHandlers: List[DataPathH
             Some(dataSource)
           }
         } catch {
-          case e: Exception => if (shouldSkipFeature) None else throw e
+          case e: Exception => if (shouldSkipFeature || shouldAddDefaultCol) None else throw e
         }
 
         anchorsWithDate.map(anchor => (anchor, timeSeriesSource))

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/AnchoredFeaturesIntegTest.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/AnchoredFeaturesIntegTest.scala
@@ -408,7 +408,7 @@ class AnchoredFeaturesIntegTest extends FeathrIntegTest {
           | features: {
           |   key: a_id
           |   featureList: ["featureWithNull", "derived_featureWithNull", "featureWithNull2", "featureWithNull3", "featureWithNull4",
-          |    "featureWithNull5", "derived_featureWithNull2", "featureWithNull6",
+          |    "featureWithNull5", "derived_featureWithNull2", "featureWithNull6", "featureWithNull7", "derived_featureWithNull7"
           |    "aEmbedding", "memberEmbeddingAutoTZ"]
           | }
       """.stripMargin,
@@ -447,6 +447,9 @@ class AnchoredFeaturesIntegTest extends FeathrIntegTest {
           |         def: "isPresent(value) ? toNumeric(value) : 0"
           |         type: CATEGORICAL
           |         default: "null"
+          |      }
+          |      featureWithNull7: {
+          |         def: "isPresent(value) ? toNumeric(value) : 0"
           |      }
           |      featureWithNull4: {
           |         def: "isPresent(value) ? toNumeric(value) : 0"
@@ -506,6 +509,7 @@ class AnchoredFeaturesIntegTest extends FeathrIntegTest {
           |
           | derived_featureWithNull: "featureWithNull * 2"
           | derived_featureWithNull2: "featureWithNull2 * 2"
+          | derived_featureWithNull7: "featureWithNull7 * 2"
           |}
         """.stripMargin,
       observationDataPath = "anchorAndDerivations/testMVELLoopExpFeature-observations.csv")
@@ -516,11 +520,14 @@ class AnchoredFeaturesIntegTest extends FeathrIntegTest {
       Row(mutable.WrappedArray.make(Array("")), mutable.WrappedArray.make(Array(2.0f))))
     assertEquals(featureList(0).getAs[Row]("featureWithNull3"), "null")
     assertEquals(featureList(0).getAs[Row]("featureWithNull5"), mutable.Map("" -> 1.0f))
+    assertEquals(featureList(0).getAs[Row]("featureWithNull7"), null)
     assertEquals(featureList(0).getAs[Row]("featureWithNull"),-1.0f)
     assertEquals(featureList(0).getAs[Row]("featureWithNull4"),Map())
     assertEquals(featureList(0).getAs[Row]("featureWithNull2"),1.0f)
     assertEquals(featureList(0).getAs[Row]("derived_featureWithNull"),
       Row(mutable.WrappedArray.make(Array("")), mutable.WrappedArray.make(Array(-2.0f))))
+    assertEquals(featureList(0).getAs[Row]("derived_featureWithNull7"),
+      Row(mutable.WrappedArray.make(Array()), mutable.WrappedArray.empty))
     assertEquals(featureList(0).getAs[Row]("derived_featureWithNull2"),
       Row(mutable.WrappedArray.make(Array("")), mutable.WrappedArray.make(Array(2.0f))))
     setFeathrJobParam(ADD_DEFAULT_COL_FOR_MISSING_DATA, "false")

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/join/workflow/TestAnchoredFeatureJoinStep.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/join/workflow/TestAnchoredFeatureJoinStep.scala
@@ -43,6 +43,8 @@ class TestAnchoredFeatureJoinStep extends TestFeathr with MockitoSugar {
       .thenReturn("false")
     when(mockSparkContext.getConf).thenReturn(mockSparkConf)
     when(mockSparkSession.sparkContext).thenReturn(mockSparkContext)
+    when(mockSparkConf.get(s"${FeathrUtils.FEATHR_PARAMS_PREFIX}${FeathrUtils.ADD_DEFAULT_COL_FOR_MISSING_DATA}",
+      "false")).thenReturn("false")
     when(mockExecutionContext.sparkSession).thenReturn(mockSparkSession)
     when(mockLogicalPlan.joinStages).thenReturn(Seq.empty)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.0.2-rc9
+version=1.0.3-rc1
 SONATYPE_AUTOMATIC_RELEASE=true
 POM_ARTIFACT_ID=feathr_2.12


### PR DESCRIPTION
If the add.default.col.for.missing.data flag is turned on, this commit will add a null value to the features if data is missing for it. If the feature has a default value configured, the default value column will be added.

Also, we need to ensure that setting the flag is done through a single spark session. One of the SWA test was setting this flag but using a different spark session which caused test failures.