### PR TITLE
Fix bug when skipping missing feature data

### DIFF
--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/util/AclCheckUtils.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/util/AclCheckUtils.scala
@@ -68,11 +68,12 @@ private[offline] object AclCheckUtils {
     } yield featureAnchorWithSource.source.path
 
     val shouldSkipFeature = FeathrUtils.getFeathrJobParam(ss.sparkContext.getConf, FeathrUtils.SKIP_MISSING_FEATURE).toBoolean
+    val shouldAddDefaultCol = FeathrUtils.getFeathrJobParam(ss.sparkContext.getConf, FeathrUtils.SKIP_MISSING_FEATURE).toBoolean
     val invalidPaths = AclCheckUtils.checkReadAuthorization(conf, allRequiredPaths.distinct)
     if (invalidPaths.isEmpty) {
       (Success(()), invalidPaths.map(_._2))
     } else {
-      if (!shouldSkipFeature) {
+      if (!shouldSkipFeature || !shouldAddDefaultCol) {
         (Failure(
           new RuntimeException(
             "Can not verify read authorization on the following paths. This can be due to" +


### PR DESCRIPTION
Bug:-

When skipping features, the innermost method was not identifying the shouldAddDefaultCol flag.