### PR TITLE
fix: update init arguments for SourceDef and SourceAttributes class t…

### DIFF
--- a/registry/purview-registry/registry/models.py
+++ b/registry/purview-registry/registry/models.py
@@ -433,7 +433,7 @@ class SourceAttributes(Attributes):
                  qualified_name: str,
                  name: str,
                  type: str,
-                 path: str,
+                 path: str = None,
                  preprocessing: Optional[str] = None,
                  event_timestamp_column: Optional[str] = None,
                  timestamp_format: Optional[str] = None,
@@ -698,9 +698,12 @@ class ProjectDef:
 class SourceDef:
     def __init__(self,
                  name: str,
-                 path: str,
                  type: str,
                  qualified_name: str = "",
+                 path: str = None,
+                 brokers: List[str] = None,
+                 topics: List[str] = None,
+                 schema: str = None,
                  preprocessing: Optional[str] = None,
                  event_timestamp_column: Optional[str] = None,
                  timestamp_format: Optional[str] = None,
@@ -709,6 +712,9 @@ class SourceDef:
         self.name = name
         self.path = path
         self.type = type
+        self.brokers = brokers
+        self.topics = topics
+        self.schema = schema
         self.preprocessing = preprocessing
         self.event_timestamp_column = event_timestamp_column
         self.timestamp_format = timestamp_format


### PR DESCRIPTION
Update init arguments for _SourceDef_ and _SourceAttributes_ classes to adopt _KafkaSource_ as Purview entity, which has been supported by a PR https://github.com/feathr-ai/feathr/pull/1167 from Xiaoyong recently.


## Description
Before this fix, when calling _client.register_features()_, it'll raise below exception from feathr web API side.
_**Failed to call registry API, status is 400, error is {"message":"__init__() got an unexpected keyword argument 'brokers'"}**_

Therefore we need to add those _KafkaSource_ specific attributes, like brokers, topics and schema, as additional optional arguments for _SourceDef_ object, and set _path_ as optional argument for _SourceAttributes_ object since it's not required by _KafakSource_ object.


## How was this PR tested?
We tested code updates in our own cloud deployment by below steps
- rebuilding a new docker image with related fixes.
- pushing the image to ACR
- updating the original web app using the new image from ACR
- testing streaming source and features registering with the new web app as well as a new wheel with code updates from Xiaoyong's PR.

It's confirmed that now streaming source and features could be registered to Purview properly and feathr UI also renders the lineage view properly.
Exp:
![image](https://github.com/feathr-ai/feathr/assets/17846095/3f7103c6-b18b-4e3e-8699-3ba6bfb62992)


## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide UI screenshot, the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.