### PR TITLE
Add TermVector support for FeatureValueWrapper

### DIFF
--- a/feathr-impl/src/main/java/com/linkedin/feathr/common/util/CoercionUtils.java
+++ b/feathr-impl/src/main/java/com/linkedin/feathr/common/util/CoercionUtils.java
@@ -2,6 +2,8 @@ package com.linkedin.feathr.common.util;
 
 import com.linkedin.feathr.common.FeatureTypes;
 import com.linkedin.feathr.common.FeatureValue;
+import com.linkedin.feathr.offline.mvel.plugins.FeatureValueWrapper;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -178,7 +180,14 @@ public class CoercionUtils {
     if (item instanceof FeatureValue) {
       // if input is already a FeatureValue, then just return its term vector representation
       return ((FeatureValue) item).getAsTermVector();
-    } else if (item instanceof Collection) {
+    } else if (item instanceof FeatureValueWrapper) {
+      Object fv = ((FeatureValueWrapper) item).getFeatureValue();
+      if (fv instanceof FeatureValue) {
+        return ((FeatureValue) item).getAsTermVector();
+      } else {
+        throw new RuntimeException("Input FeatureValueWrapper " + item + " cannot be converted to feature value.");
+      }
+    }else if (item instanceof Collection) {
       Collection<?> collection = (Collection<?>) item;
       if (collection.isEmpty()) {
         return Collections.emptyMap();

--- a/feathr-impl/src/test/scala/com/linkedin/feathr/offline/TestFeathrUdfPlugins.scala
+++ b/feathr-impl/src/test/scala/com/linkedin/feathr/offline/TestFeathrUdfPlugins.scala
@@ -1,6 +1,7 @@
 package com.linkedin.feathr.offline
 
 import com.linkedin.feathr.common.FeatureValue
+import com.linkedin.feathr.common.util.CoercionUtils
 import com.linkedin.feathr.offline.anchored.keyExtractor.AlienSourceKeyExtractorAdaptor
 import com.linkedin.feathr.offline.client.plugins.FeathrUdfPluginContext
 import com.linkedin.feathr.offline.derived.AlienDerivationFunctionAdaptor
@@ -12,6 +13,8 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{FloatType, StringType, StructField, StructType}
 import org.testng.Assert.{assertEquals, assertTrue}
 import org.testng.annotations.{BeforeClass, Test}
+import scala.collection.JavaConverters._
+
 class TestFeathrUdfPlugins extends FeathrIntegTest {
 
   val MULTILINE_QUOTE = "\"\"\""
@@ -32,6 +35,7 @@ class TestFeathrUdfPlugins extends FeathrIntegTest {
     val featureFeatureValueAsAlien = new FeathrFeatureValueAsAlien(featureValue)
     assertTrue(mvelContext.canConvert(FeatureValue.getClass, featureFeatureValueAsAlien.getClass))
     assertEquals(mvelContext.convert(featureFeatureValueAsAlien, FeatureValue.getClass), featureValue)
+    assertEquals(CoercionUtils.coerceToVector(featureValue),  Map("" -> 2.0f).asJava)
   }
 
   @Test (enabled = true)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.0.4-rc7
+version=1.0.4-rc8
 SONATYPE_AUTOMATIC_RELEASE=true
 POM_ARTIFACT_ID=feathr_2.12


### PR DESCRIPTION
## Description 
Add TermVector coercion support for FeatureValueWrapper. This is needed in derived feature where the base feature returns alien feature values.

## How was this PR tested? 
Add test.