### PR TITLE
Fix get_features_from_registry() issue for registered streaming sources & features

### DIFF
--- a/feathr_project/feathr/registry/_feathr_registry_client.py
+++ b/feathr_project/feathr/registry/_feathr_registry_client.py
@@ -224,7 +224,7 @@ def dict_to_source(v: dict) -> Source:
                                 registry_tags=v["attributes"].get("tags", {}))
     elif type == "kafka":
         # print('v["attributes"]', v["attributes"])
-        kafka_config = KafkaConfig(brokers=v["attributes"]["brokers"], topics=v["attributes"]["topics"], schema=AvroJsonSchema(schemaStr= v["attributes"]["schema"]))
+        kafka_config = KafkaConfig(brokers=v["attributes"].get("brokers", []), topics=v["attributes"].get ("topics", []), schema=AvroJsonSchema(schemaStr= v["attributes"].get("schemaStr", "")))
         source = KafKaSource(name=v["attributes"]["name"], kafkaConfig=kafka_config, registry_tags=v["attributes"].get("tags", {}))
     elif type == "generic":
         options = v["attributes"].copy()

--- a/feathr_project/feathr/registry/registry_utils.py
+++ b/feathr_project/feathr/registry/registry_utils.py
@@ -47,7 +47,7 @@ def source_to_def(source: Source) -> dict:
             "type": "kafka",
             "brokers":source.config.brokers,
             "topics":source.config.topics,
-            "schema":source.config.schema.schemaStr
+            "schemaStr":source.config.schema.schemaStr
         }
         print("ret is", ret)
     elif isinstance(source, SnowflakeSource):

--- a/registry/purview-registry/registry/models.py
+++ b/registry/purview-registry/registry/models.py
@@ -434,6 +434,9 @@ class SourceAttributes(Attributes):
                  name: str,
                  type: str,
                  path: str = None,
+                 brokers: List[str] = None,
+                 topics: List[str] = None,
+                 schema_str: str = None,
                  preprocessing: Optional[str] = None,
                  event_timestamp_column: Optional[str] = None,
                  timestamp_format: Optional[str] = None,
@@ -442,6 +445,9 @@ class SourceAttributes(Attributes):
         self.name = name
         self.type = type
         self.path = path
+        self.brokers = brokers
+        self.topics = topics
+        self.schema_str = schema_str
         self.preprocessing = preprocessing
         self.event_timestamp_column = event_timestamp_column
         self.timestamp_format = timestamp_format
@@ -459,6 +465,12 @@ class SourceAttributes(Attributes):
             "path": self.path,
             "tags": self.tags,
         }
+        if self.brokers is not None:
+            ret["brokers"] = self.brokers
+        if self.topics is not None:
+            ret["topics"] = self.topics
+        if self.schema_str is not None:
+            ret["schemaStr"] = self.schema_str
         if self.preprocessing is not None:
             ret["preprocessing"] = self.preprocessing
         if self.event_timestamp_column is not None:
@@ -703,7 +715,7 @@ class SourceDef:
                  path: str = None,
                  brokers: List[str] = None,
                  topics: List[str] = None,
-                 schema: str = None,
+                 schema_str: str = None,
                  preprocessing: Optional[str] = None,
                  event_timestamp_column: Optional[str] = None,
                  timestamp_format: Optional[str] = None,
@@ -714,7 +726,7 @@ class SourceDef:
         self.type = type
         self.brokers = brokers
         self.topics = topics
-        self.schema = schema
+        self.schema_str = schema_str
         self.preprocessing = preprocessing
         self.event_timestamp_column = event_timestamp_column
         self.timestamp_format = timestamp_format
@@ -725,6 +737,9 @@ class SourceDef:
                                 name=self.name,
                                 type=self.type,
                                 path=self.path,
+                                brokers=self.brokers,
+                                topics=self.topics,
+                                schema_str=self.schema_str,
                                 preprocessing=self.preprocessing,
                                 event_timestamp_column=self.event_timestamp_column,
                                 timestamp_format=self.timestamp_format,

--- a/registry/purview-registry/registry/models.py
+++ b/registry/purview-registry/registry/models.py
@@ -433,7 +433,7 @@ class SourceAttributes(Attributes):
                  qualified_name: str,
                  name: str,
                  type: str,
-                 path: str,
+                 path: str = None,
                  preprocessing: Optional[str] = None,
                  event_timestamp_column: Optional[str] = None,
                  timestamp_format: Optional[str] = None,
@@ -698,9 +698,12 @@ class ProjectDef:
 class SourceDef:
     def __init__(self,
                  name: str,
-                 path: str,
                  type: str,
                  qualified_name: str = "",
+                 path: str = None,
+                 brokers: List[str] = None,
+                 topics: List[str] = None,
+                 schema: str = None,
                  preprocessing: Optional[str] = None,
                  event_timestamp_column: Optional[str] = None,
                  timestamp_format: Optional[str] = None,
@@ -709,6 +712,9 @@ class SourceDef:
         self.name = name
         self.path = path
         self.type = type
+        self.brokers = brokers
+        self.topics = topics
+        self.schema = schema
         self.preprocessing = preprocessing
         self.event_timestamp_column = event_timestamp_column
         self.timestamp_format = timestamp_format

--- a/registry/purview-registry/registry/purview_registry.py
+++ b/registry/purview-registry/registry/purview_registry.py
@@ -524,6 +524,12 @@ class PurviewRegistry(Registry):
 
                 AtlasAttributeDef(
                     name="path", typeName="string", cardinality=Cardinality.SINGLE),
+                AtlasAttributeDef(name="brokers",
+                                  typeName="array<string>", cardinality=Cardinality.SINGLE),
+                AtlasAttributeDef(name="topics",
+                                  typeName="array<string>", cardinality=Cardinality.SINGLE),
+                AtlasAttributeDef(name="schemaStr",
+                                  typeName="string", cardinality=Cardinality.SINGLE),
                 AtlasAttributeDef(name="event_timestamp_column",
                                   typeName="string", cardinality=Cardinality.SINGLE),
                 AtlasAttributeDef(name="timestamp_format",


### PR DESCRIPTION
## Description
<!--
Hey! Thank you for the contribution! Please go through https://github.com/feathr-ai/feathr/blob/main/docs/dev_guide/pull_request_guideline.md for more information.

Describe what changes to make and why you are making these changes.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Resolves below error when calling _client.get_features_from_registry("project_name")_ and the target project contains registered Kafka streaming sources & features, which was supported a while ago by these these two PRs, [#1167](https://github.com/feathr-ai/feathr/pull/1167) and [#1174](https://github.com/feathr-ai/feathr/pull/1174).
<img src="https://github.com/feathr-ai/feathr/assets/17846095/8a95bc5b-9d58-4053-8f92-9a9a459faaa9" width=800x>

The root cause of above exception is that we haven't added the Kafka source specific attributes, **_brokers_**, **_topics_** and **_schemaStr_** to the custom Atlas Type _**feature_source_v1**_ yet, and the smoke tests we did previously was mainly focusing on building and registering streaming features, but not on getting features so that this bug was missed.

**Major changes of this PR**:
- Added those three streaming source specific attributes to _feature_source_v1_ type; the reason why we picked _schemaStr_ over _schema_ is that we tested attribute name _schema_ and noticed it conflicts with a default relationship attribute also names _schema_, which is inherited from super type _DataSet_
  <img src="https://github.com/feathr-ai/feathr/assets/17846095/39a3b391-1912-436f-858c-69e1a781b934" width=500x>

- Updated _get_features_from_registry()_ logic to return default values if _brokers_, _topics_ or _schemaStr_ attributes was not set for those streaming sources registered before this PR fix. 


## How was this PR tested?
<!--
Describe what testings you have done. If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- Did some smoke tests on registering streaming features with rebuilt feathr client and feathr web app, confirms that new added _feathr_source_v1_ attributes are filled in with expected values.
  <img src="https://github.com/feathr-ai/feathr/assets/17846095/f713d284-9bfd-4044-b664-046da99dc571" width=400x>

- Also tested getting streaming features, the previous exception has gone.


## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide UI screenshot, the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.