### PR TITLE
Add spark.feathr.output.parallelism to control output partitions

### DIFF
--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/util/FeathrUtils.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/util/FeathrUtils.scala
@@ -18,6 +18,7 @@ private[feathr] object FeathrUtils {
   val DEBUG_FEATURE_NAMES = "debug.feature.names"
   val DEBUG_OUTPUT_PATH = "debug.output.path"
   val DEBUG_OUTPUT_PART_NUM = "debug.output.num.parts"
+  val OUTPUT_PARALLELISM = "output.parallelism"
   val FEATHR_PARAMS_PREFIX = "spark.feathr."
   /*
    * The execution config controls feathr-offline behavior when loading date partitioned feature data.
@@ -67,6 +68,7 @@ private[feathr] object FeathrUtils {
     // Check point every {CHECKPOINT_FREQUENCY} dataframes
     CHECKPOINT_FREQUENCY  -> (SQLConf.buildConf(getFullConfigKeyName(CHECKPOINT_FREQUENCY )).stringConf.createOptional, "10"),
     DEBUG_OUTPUT_PART_NUM  -> (SQLConf.buildConf(getFullConfigKeyName(DEBUG_OUTPUT_PART_NUM )).stringConf.createOptional, "200"),
+    OUTPUT_PARALLELISM  -> (SQLConf.buildConf(getFullConfigKeyName(OUTPUT_PARALLELISM )).stringConf.createOptional, "200"),
     FAIL_ON_MISSING_PARTITION  -> (SQLConf.buildConf(getFullConfigKeyName(FAIL_ON_MISSING_PARTITION )).stringConf.createOptional, "false"),
     SEQ_JOIN_ARRAY_EXPLODE_ENABLED  -> (SQLConf.buildConf(getFullConfigKeyName(SEQ_JOIN_ARRAY_EXPLODE_ENABLED )).stringConf.createOptional, "true"),
     ENABLE_SALTED_JOIN  -> (SQLConf.buildConf(getFullConfigKeyName(ENABLE_SALTED_JOIN )).stringConf.createOptional, "false"),

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.0.5-rc1
+version=1.0.5-rc2
 SONATYPE_AUTOMATIC_RELEASE=true
 POM_ARTIFACT_ID=feathr_2.12


### PR DESCRIPTION
1. Add spark.feathr.output.parallelism to control output partitions in writing output dataframes.
2. Use repartition to increase number of partition if necessary.