### PR TITLE
Add String Column Support for Count Distinct Aggregation

### DIFF
--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/swa/SlidingWindowFeatureUtils.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/swa/SlidingWindowFeatureUtils.scala
@@ -186,7 +186,9 @@ private[offline] object SlidingWindowFeatureUtils {
         // In Feathr's use case, we want to treat the count aggregation as simple count of non-null items.
         val rewrittenDef = s"CASE WHEN ${featureDef} IS NOT NULL THEN 1 ELSE 0 END"
         new CountAggregate(rewrittenDef)
-      case AggregationType.COUNT_DISTINCT => new CountDistinctAggregate(featureDef)
+      case AggregationType.COUNT_DISTINCT =>
+        var rewrittenDef = s"CASE WHEN ${featureDef} IS NOT NULL THEN CAST(CONV(MD5(${featureDef}), 16, 10) AS INT)  ELSE 0 END"
+        new CountDistinctAggregate(rewrittenDef)
       case AggregationType.AVG => new AvgAggregate(featureDef)
       case AggregationType.MAX => new MaxAggregate(featureDef)
       case AggregationType.MIN => new MinAggregate(featureDef)


### PR DESCRIPTION
## Add String Support for Count Distinct Aggregation
Currently, feathr doesn't support the COUNT_DISTINCT aggregation on string column types, since it assumes the data type from the schema prior to the aggregation. When we try applying COUNT_DISTINCT on string columns, we get this error: 

`Caused by: Job aborted due to stage failure: Error while encoding: java.lang.RuntimeException: java.lang.Integer is not a valid external type for schema of string`

This PR converts each string into a unique 32 bit number using MD5 hash algorithm such that COUNT_DISTINCT aggregations can also work on string columns. 

Resolves #XXX

## How was this PR tested?
I ran spark jobs locally and saw them fail before this change, and succeed after this change.

## Does this PR introduce any user-facing changes?

COUNT_DISTINCT should now work on string columns.

- [ ] No. You can skip the rest of this section.
- [x ] Yes. Make sure to clarify your proposed changes.