### PR TITLE
[Hdfs Utils] add uri param to filesystem get api

### DIFF
--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/util/HdfsUtils.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/util/HdfsUtils.scala
@@ -6,6 +6,7 @@ import org.apache.hadoop.fs.{FileSystem, LocatedFileStatus, Path, PathFilter, Re
 import org.apache.log4j.{Logger, PatternLayout, WriterAppender}
 
 import java.io.{FileSystem => _, _}
+import java.net.URI
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import java.time.{LocalDateTime, ZoneId, ZoneOffset}
@@ -451,7 +452,7 @@ object HdfsUtils {
    * @return true if exists else false.
    */
   def exists(path: String, conf: Configuration = conf): Boolean = {
-    FileSystem.get(conf).exists(new Path(path))
+    FileSystem.get(URI.create(path), conf).exists(new Path(path))
   }
 
   /**
@@ -489,7 +490,7 @@ object HdfsUtils {
    * @return true if nonEmpty
    */
   def nonEmpty(inputPath: String, conf: Configuration = conf): Boolean = {
-    val fs = FileSystem.get(conf)
+    val fs = FileSystem.get(URI.create(inputPath), conf)
     val path = new Path(inputPath)
     if (!exists(inputPath)) return false
     if (fs.getFileStatus(path).isDirectory) {


### PR DESCRIPTION
## Description

when HDFS is configured with fs.defaultsFS pointing to blob storage, we are not able to give local path as source location in feature definition config. this is because hdfsutils.scala uses FileSystem.get(conf) API. instead using FileSystem.get(URI, conf) solves the problem where one can give source location as file:///xyz even though defaultFS points to blob.

## Testing
manually tested using notebook session configured with fs.defaultFS= wasbs://xyz
FileSystem.get(conf).exists("file:///path") returns false
FileSystem.get(URI, conf).exists("file:///path") returns true

## Does this PR introduce any user-facing changes?
- [X ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.