### PR TITLE
add unity catalog suppot

### DIFF
--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/source/dataloader/BatchDataLoader.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/source/dataloader/BatchDataLoader.scala
@@ -97,7 +97,8 @@ private[offline] class BatchDataLoader(ss: SparkSession, location: DataLocation,
       }
       df
     } catch {
-      case _: Throwable =>
+      case e: Throwable =>
+        e.printStackTrace() // This prints the stack trace of the Throwable
         try {
           new AvroJsonDataLoader(ss, dataPath + "/data.avro.json").loadDataFrame()
         } catch {
@@ -106,6 +107,7 @@ private[offline] class BatchDataLoader(ss: SparkSession, location: DataLocation,
               ss.read.format("csv").option("header", "true").option("delimiter", csvDelimiterOption).load(dataPath)
             } catch {
               case e: Exception =>
+                e.printStackTrace()
                 // If data loading from source failed, retry it automatically, as it might due to data source still being written into.
                 log.info(s"Loading ${location} failed, retrying for ${retry}-th time..")
                 if (retry > 0) {

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/util/AclCheckUtils.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/util/AclCheckUtils.scala
@@ -33,7 +33,7 @@ private[offline] object AclCheckUtils {
   // Check read authorization on a path string
   def checkReadAuthorization(conf: Configuration, pathName: String): Try[Unit] = {
     // no way to check jdbc auth yet
-    if (pathName.startsWith("jdbc:")) {
+    if (pathName.startsWith("jdbc:") || pathName.startsWith("unity:")) {{
       Success(())
     } else {
       val path = new Path(pathName)

--- a/feathr-impl/src/main/scala/com/linkedin/feathr/offline/util/AclCheckUtils.scala
+++ b/feathr-impl/src/main/scala/com/linkedin/feathr/offline/util/AclCheckUtils.scala
@@ -33,7 +33,7 @@ private[offline] object AclCheckUtils {
   // Check read authorization on a path string
   def checkReadAuthorization(conf: Configuration, pathName: String): Try[Unit] = {
     // no way to check jdbc auth yet
-    if (pathName.startsWith("jdbc:") || pathName.startsWith("unity:")) {{
+    if (pathName.startsWith("jdbc:") || pathName.startsWith("unity:")) {
       Success(())
     } else {
       val path = new Path(pathName)


### PR DESCRIPTION
This adds unity catalog support through a path prefix: "unity:". Note that this only works if the databricks cluster running has the appropriate required permissions within databricks to access the catalog. I also added some extra logging as I ran into issues with permissions and exception message was not being surfaced.